### PR TITLE
Update BuildValuesForDirective

### DIFF
--- a/src/Extensions/StringBuilderExtentions.cs
+++ b/src/Extensions/StringBuilderExtentions.cs
@@ -17,8 +17,9 @@ namespace OwaspHeaders.Core.Extensions
         {
             if (!directiveValues.Any()) return stringBuilder;
             
-            @stringBuilder.Append(directiveName);
-            directiveValues.Select(s => @stringBuilder.Append($"'{s}' "));
+            @stringBuilder.Append(directiveName);            
+            @stringBuilder.Append(" ");
+            @stringBuilder.Append(string.Join(' ', directiveValues));
             @stringBuilder.Append(";");
             return stringBuilder;
         }


### PR DESCRIPTION
Attempting to set a CSP policy of "script-src 'self' cdn.auth0.com;" incorrectly generates "script-src 'self';" despite secureHeaderSettings.json being set to "ScriptSrc": ["'self'","cdn.auth0.com"] .

Modifying StringBuilderExtensions.BuildValuesForDirective as below resolves the issue:

//directiveValues.Select(s => @stringBuilder.Append($"'{s}' "));
@stringBuilder.Append(" ");
@stringBuilder.Append(string.Join(' ', directiveValues));