### PR TITLE
Fixes #16 and #17

### DIFF
--- a/src/Enums/CspCommandType.cs
+++ b/src/Enums/CspCommandType.cs
@@ -1,0 +1,8 @@
+﻿namespace OwaspHeaders.Core.Enums
+{
+    public enum CspCommandType
+    {
+        Directive,
+        Uri
+    }
+}

--- a/src/Extensions/ContentSecurityPolicyExtensions.cs
+++ b/src/Extensions/ContentSecurityPolicyExtensions.cs
@@ -10,7 +10,8 @@ namespace OwaspHeaders.Core.Extensions
         /// Used to set the Content Security Policy URIs for a given <see cref="CspUriType"/>
         /// </summary>
         public static SecureHeadersMiddlewareConfiguration SetCspUris
-            (this SecureHeadersMiddlewareConfiguration config, List<string> baseUri, CspUriType cspUriType)
+            (this SecureHeadersMiddlewareConfiguration config, List<ContenSecurityPolicyElement> baseUri,
+            CspUriType cspUriType)
         {
             if (config.UseContentSecurityPolicy)
             {

--- a/src/Extensions/SecureHeadersMiddlewareBuilder.cs
+++ b/src/Extensions/SecureHeadersMiddlewareBuilder.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using OwaspHeaders.Core.Enums;
+using OwaspHeaders.Core.Helpers;
 using OwaspHeaders.Core.Models;
 
 namespace OwaspHeaders.Core.Extensions
@@ -67,6 +68,7 @@ namespace OwaspHeaders.Core.Extensions
                 XFrameOptions xFrameOption = XFrameOptions.deny,
                 string domain = null)
         {
+            config.UseXFrameOptions = true;
             config.XFrameOptionsConfiguration = new XFrameOptionsConfiguration(xFrameOption, domain);
             
             return config;
@@ -90,6 +92,7 @@ namespace OwaspHeaders.Core.Extensions
                 XssMode xssMode = XssMode.oneBlock,
                 string reportUri = null)
         {
+            config.UseXssProtection = true;
             config.XssConfiguration = new XssConfiguration(xssMode, reportUri);
             return config;
         }
@@ -126,11 +129,18 @@ namespace OwaspHeaders.Core.Extensions
         public static SecureHeadersMiddlewareConfiguration UseContentDefaultSecurityPolicy
         (this SecureHeadersMiddlewareConfiguration config)
         {
+            config.UseContentSecurityPolicy = true;
+            
             config.ContentSecurityPolicyConfiguration = new ContentSecurityPolicyConfiguration
                 (null, true, true, null, null);
 
-            config.SetCspUris(new List<string> {"self"}, CspUriType.Script);
-            config.SetCspUris(new List<string> {"self"}, CspUriType.Object);
+            config.SetCspUris(
+                new List<ContenSecurityPolicyElement> {ContentSecurityPolicyHelpers.CreateSelfDirective()},
+                CspUriType.Script);
+
+            config.SetCspUris(
+                new List<ContenSecurityPolicyElement> {ContentSecurityPolicyHelpers.CreateSelfDirective()},
+                CspUriType.Object);
             
             return config;
         }
@@ -139,6 +149,10 @@ namespace OwaspHeaders.Core.Extensions
         /// CSP prevents a wide range of attacks, including Cross-site scripting and other
         /// cross-site injections.
         /// </summary>
+        /// <param name="pluginTypes">
+        /// The set of plugins that can be invoked by the protected resource by limiting the
+        /// types of resources that can be embedded
+        /// </param>
         /// <param name="blockAllMixedContent">
         /// Prevent user agent from loading mixed content.
         /// </param>
@@ -148,12 +162,18 @@ namespace OwaspHeaders.Core.Extensions
         /// <param name="reportUri">
         /// Specifies a URI to which the user agent sends reports about policy violation.
         /// </param>
+        /// <remarks>
+        /// Requires consumer to set up their own Content Security Policy Rules via calls to
+        /// SetCspUris, which is an extension method on the <see cref="SecureHeadersMiddlewareConfiguration"/> object
+        /// </remarks>
         public static SecureHeadersMiddlewareConfiguration UseContentSecurityPolicy
             (this SecureHeadersMiddlewareConfiguration config,
                 string pluginTypes = null, bool blockAllMixedContent = true,
                 bool upgradeInsecureRequests = true, string referrer = null,
                 string reportUri = null)
         {
+            config.UseContentSecurityPolicy = true;
+            
             config.ContentSecurityPolicyConfiguration = new ContentSecurityPolicyConfiguration
                 (pluginTypes, blockAllMixedContent, upgradeInsecureRequests, referrer, reportUri);
             
@@ -172,6 +192,8 @@ namespace OwaspHeaders.Core.Extensions
             XPermittedCrossDomainOptionValue xPermittedCrossDomainOptionValue =
                 XPermittedCrossDomainOptionValue.none)
         {
+            config.UsePermittedCrossDomainPolicy = true;
+            
             config.PermittedCrossDomainPolicyConfiguration =
                 new PermittedCrossDomainPolicyConfiguration(xPermittedCrossDomainOptionValue);
 
@@ -190,6 +212,8 @@ namespace OwaspHeaders.Core.Extensions
                 ReferrerPolicyOptions referrerPolicyOption =
                     ReferrerPolicyOptions.noReferrer)
         {
+            config.UseReferrerPolicy = true;
+            
             config.ReferrerPolicy = new ReferrerPolicy(referrerPolicyOption);
             return config;
         }

--- a/src/Extensions/StringBuilderExtentions.cs
+++ b/src/Extensions/StringBuilderExtentions.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using OwaspHeaders.Core.Enums;
+using OwaspHeaders.Core.Models;
+
 namespace OwaspHeaders.Core.Extensions
 {
     public static class StringBuilderExtentions
@@ -13,13 +16,26 @@ namespace OwaspHeaders.Core.Extensions
         /// <param name="directiveValues">A list of strings representing the directive values</param>
         /// <returns>The updated <see cref="StringBuilder" /> instance</returns>
         public static StringBuilder BuildValuesForDirective(this StringBuilder @stringBuilder,
-            string directiveName, List<string> directiveValues)
+            string directiveName, List<ContenSecurityPolicyElement> directiveValues)
         {
             if (!directiveValues.Any()) return stringBuilder;
             
             @stringBuilder.Append(directiveName);            
-            @stringBuilder.Append(" ");
-            @stringBuilder.Append(string.Join(" ", directiveValues));
+            if (directiveValues.Any(d => d.CommandType == CspCommandType.Directive))
+            {
+                @stringBuilder.Append(" ");
+                @stringBuilder.Append(string.Join(" ",
+                    directiveValues.Where(command => (command.CommandType == CspCommandType.Directive))
+                        .Select(directive => $"'{directive.DirectiveOrUri}'")));
+            }
+
+            if (directiveValues.Any(d => d.CommandType == CspCommandType.Uri))
+            {
+                @stringBuilder.Append(" ");
+                @stringBuilder.Append(string.Join(" ",
+                    directiveValues.Where(command => (command.CommandType == CspCommandType.Uri))
+                        .Select(e => e.DirectiveOrUri)));
+            }
             @stringBuilder.Append(";");
             return stringBuilder;
         }

--- a/src/Helpers/ContentSecurityPolicyHelpers.cs
+++ b/src/Helpers/ContentSecurityPolicyHelpers.cs
@@ -1,0 +1,26 @@
+using OwaspHeaders.Core.Enums;
+using OwaspHeaders.Core.Models;
+
+namespace OwaspHeaders.Core.Helpers
+{
+    public static class ContentSecurityPolicyHelpers
+    {
+        /// <summary>
+        /// Used to create the default "self" CSP directive.
+        /// This can be applied to any of the CSP rules individually
+        /// or to the 'default-src' rule to cover them all.
+        /// </summary>
+        /// <returns>
+        /// A new instance of the <see cref="ContenSecurityPolicyElement"/>
+        /// class which represents a 'self' CSP rule.
+        /// </returns>
+        public static ContenSecurityPolicyElement CreateSelfDirective()
+        {
+            return new ContenSecurityPolicyElement
+            {
+                CommandType = CspCommandType.Directive,
+                DirectiveOrUri = "self"
+            };
+        }
+    }
+}

--- a/src/Models/ContenSecurityPolicyElement.cs
+++ b/src/Models/ContenSecurityPolicyElement.cs
@@ -1,0 +1,10 @@
+using OwaspHeaders.Core.Enums;
+
+namespace OwaspHeaders.Core.Models
+{
+    public class ContenSecurityPolicyElement
+    {
+        public CspCommandType CommandType { get; set; }
+        public string DirectiveOrUri { get; set; }
+    }
+}

--- a/src/Models/ContentSecurityPolicyConfiguration.cs
+++ b/src/Models/ContentSecurityPolicyConfiguration.cs
@@ -11,72 +11,72 @@ namespace OwaspHeaders.Core.Models
         /// <summary>
         /// The base-uri values to use (which can be used in a document's base element)
         /// </summary>
-        public List<string> BaseUri { get; set; }
+        public List<ContenSecurityPolicyElement> BaseUri { get; set; }
 
         /// <summary>
         /// The default-src values to use (as a fallback for the other CSP rules)
         /// </summary>
-        public List<string> DefaultSrc { get; set; }
+        public List<ContenSecurityPolicyElement> DefaultSrc { get; set; }
 
         /// <summary>
         /// The script-src values to use (valid sources for sources for JavaScript)
         /// </summary>
-        public List<string> ScriptSrc { get; set; }
+        public List<ContenSecurityPolicyElement> ScriptSrc { get; set; }
 
         /// <summary>
         /// The object-src values to use (valid sources for the object, embed, and applet elements)
         /// </summary>
-        public List<string> ObjectSrc { get; set; }
+        public List<ContenSecurityPolicyElement> ObjectSrc { get; set; }
 
         /// <summary>
         /// The style-src values to use (valid sources for style sheets)
         /// </summary>
-        public List<string> StyleSrc { get; set; }
+        public List<ContenSecurityPolicyElement> StyleSrc { get; set; }
 
         /// <summary>
         /// The img-src values to use (valid sources for images and favicons)
         /// </summary>
-        public List<string> ImgSrc { get; set; }
+        public List<ContenSecurityPolicyElement> ImgSrc { get; set; }
 
         /// <summary>
         /// The media-src values to use (valid sources for loading media using the audio and video elements)
         /// </summary>
-        public List<string> MediaSrc { get; set; }
+        public List<ContenSecurityPolicyElement> MediaSrc { get; set; }
 
         /// <summary>
         /// The frame-src values to use (valid sources for nested browsing contexts loading using elements such as frame and iframe)
         /// </summary>
-        public List<string> FrameSrc { get; set; }
+        public List<ContenSecurityPolicyElement> FrameSrc { get; set; }
 
         /// <summary>
         /// The child-src values to use (valid sources for web workers and nested browsing contexts loaded using elements such as frame and iframe)
         /// </summary>
-        public List<string> ChildSrc { get; set; }
+        public List<ContenSecurityPolicyElement> ChildSrc { get; set; }
 
         /// <summary>
         /// The frame-ancestors values to use (valid parents that may embed a page using frame, iframe, object, embed, or applet)
         /// </summary>
-        public List<string> FrameAncestors { get; set; }
+        public List<ContenSecurityPolicyElement> FrameAncestors { get; set; }
 
         /// <summary>
         /// The font-src values to use (valid sources for fonts loaded using @font-face)
         /// </summary>
-        public List<string> FontSrc { get; set; }
+        public List<ContenSecurityPolicyElement> FontSrc { get; set; }
 
         /// <summary>
         /// The connect-src values to use (restricts the URLs which can be loaded using script interfaces)
         /// </summary>
-        public List<string> ConnectSrc { get; set; }
+        public List<ContenSecurityPolicyElement> ConnectSrc { get; set; }
 
         /// <summary>
         /// The manifest-src values to use (which manifest can be applied to the resource)
         /// </summary>
-        public List<string> ManifestSrc { get; set; }
+        public List<ContenSecurityPolicyElement> ManifestSrc { get; set; }
 
         /// <summary>
         /// The form-action values to use (restricts the URLs which can be used as the target of a form submissions from a given context)
         /// </summary>
-        public List<string> FormAction { get; set; }
+        public List<ContenSecurityPolicyElement> FormAction { get; set; }
         
         /// <summary>
         /// Specifies an HTML sandbox policy that the user agent applies to the protected resource.
@@ -113,20 +113,20 @@ namespace OwaspHeaders.Core.Models
         public ContentSecurityPolicyConfiguration(string pluginTypes, bool blockAllMixedContent,
             bool upgradeInsecureRequests, string referrer, string reportUri)
         {
-            BaseUri = new List<string>();
-            DefaultSrc = new List<string>();
-            ScriptSrc = new List<string>();
-            ObjectSrc = new List<string>();
-            StyleSrc = new List<string>();
-            ImgSrc = new List<string>();
-            MediaSrc = new List<string>();
-            FrameSrc = new List<string>();
-            ChildSrc = new List<string>();
-            FrameAncestors = new List<string>();
-            FontSrc = new List<string>();
-            ConnectSrc = new List<string>();
-            ManifestSrc = new List<string>();
-            FormAction = new List<string>();
+            BaseUri = new List<ContenSecurityPolicyElement>();
+            DefaultSrc = new List<ContenSecurityPolicyElement>();
+            ScriptSrc = new List<ContenSecurityPolicyElement>();
+            ObjectSrc = new List<ContenSecurityPolicyElement>();
+            StyleSrc = new List<ContenSecurityPolicyElement>();
+            ImgSrc = new List<ContenSecurityPolicyElement>();
+            MediaSrc = new List<ContenSecurityPolicyElement>();
+            FrameSrc = new List<ContenSecurityPolicyElement>();
+            ChildSrc = new List<ContenSecurityPolicyElement>();
+            FrameAncestors = new List<ContenSecurityPolicyElement>();
+            FontSrc = new List<ContenSecurityPolicyElement>();
+            ConnectSrc = new List<ContenSecurityPolicyElement>();
+            ManifestSrc = new List<ContenSecurityPolicyElement>();
+            FormAction = new List<ContenSecurityPolicyElement>();
 
             PluginTypes = pluginTypes;
             BlockAllMixedContent = blockAllMixedContent;
@@ -191,7 +191,7 @@ namespace OwaspHeaders.Core.Models
                 stringBuilder.Append($"report-uri {ReportUri}; ");
             }
 
-            return stringBuilder.ToString();
+            return stringBuilder.ToString().TrimEnd();
         }
 
         private bool AnyValues()

--- a/src/Models/ContentSecurityPolicyExtentions.cs
+++ b/src/Models/ContentSecurityPolicyExtentions.cs
@@ -10,7 +10,8 @@ namespace OwaspHeaders.Core.Models
         /// Used to set the Content Security Policy URIs for a given <see cref="CspUriType"/>
         /// </summary>
         public static ContentSecurityPolicyConfiguration SetCspUri
-            (this ContentSecurityPolicyConfiguration @this, List<string> uris, CspUriType uriType)
+            (this ContentSecurityPolicyConfiguration @this, List<ContenSecurityPolicyElement> uris,
+            CspUriType uriType)
         {
             switch (uriType)
             {

--- a/src/Models/PermittedCrossDomainPolicyConfiguration.cs
+++ b/src/Models/PermittedCrossDomainPolicyConfiguration.cs
@@ -21,20 +21,20 @@ namespace OwaspHeaders.Core.Models
             switch (xPermittedCrossDomainOptionValue)
             {
                 case XPermittedCrossDomainOptionValue.none:
-                    return "none";
+                    return "none;";
                 case XPermittedCrossDomainOptionValue.masterOnly:
-                    return "master-only";
+                    return "master-only;";
                 case XPermittedCrossDomainOptionValue.byContentType:
-                    return "by-content-type";
+                    return "by-content-type;";
                 case XPermittedCrossDomainOptionValue.byFtpFileType:
-                    return "by-ftp-file-type";
+                    return "by-ftp-file-type;";
                 case XPermittedCrossDomainOptionValue.all:
-                    return "all";
+                    return "all;";
                 default:
                     ArgumentExceptionHelper.RaiseException(nameof(xPermittedCrossDomainOptionValue));
                     break;
             }
-            return "";
+            return ";";
         }
     }
 }

--- a/src/Models/ReferrerPolicy.cs
+++ b/src/Models/ReferrerPolicy.cs
@@ -19,25 +19,26 @@ namespace OwaspHeaders.Core.Models
             switch (ReferrerPolicyOption)
             {
                 case ReferrerPolicyOptions.noReferrer:
-                    return "no-referrer";
+                    return "no-referrer;";
                 case ReferrerPolicyOptions.noReferrerWhenDowngrade:
-                    return "no-referrer-when-downgrade";
+                    return "no-referrer-when-downgrade;";
                 case ReferrerPolicyOptions.origin:
-                    return "origin";
+                    return "origin;";
                 case ReferrerPolicyOptions.originWhenCrossOrigin:
-                    return "origin-when-cross-origin";
+                    return "origin-when-cross-origin;";
                 case ReferrerPolicyOptions.sameOrigin:
-                    return "same-origin";
+                    return "same-origin;";
                 case ReferrerPolicyOptions.strictOrigin:
-                    return "strict-origin";
+                    return "strict-origin;";
                 case ReferrerPolicyOptions.strictWhenCrossOrigin:
-                    return "strict-origin-when-cross-origin";
+                    return "strict-origin-when-cross-origin;";
                 case ReferrerPolicyOptions.unsafeUrl:
-                    return "unsafe-url";
+                    return "unsafe-url;";
                 default:
                     ArgumentExceptionHelper.RaiseException(nameof(ReferrerPolicyOption));
-                    return "";
+                    break;
             }
+            return ";";
         }
     }
 }

--- a/src/Models/XFrameOptionsConfiguration.cs
+++ b/src/Models/XFrameOptionsConfiguration.cs
@@ -27,18 +27,17 @@ namespace OwaspHeaders.Core.Models
             switch (OptionValue)
             {
                 case XFrameOptions.deny:
-                    stringBuilder.Append("deny");
+                    stringBuilder.Append("deny;");
                     break;
                 case XFrameOptions.sameorigin:
-                    stringBuilder.Append("sameorigin");
+                    stringBuilder.Append("sameorigin;");
                     break;
                 case XFrameOptions.allowfrom:
                     if (string.IsNullOrWhiteSpace(AllowFromDomain))
                     {
                         ArgumentExceptionHelper.RaiseException(nameof(AllowFromDomain));
                     }
-                    stringBuilder.Append("allow-from: ");
-                    stringBuilder.Append(AllowFromDomain);
+                    stringBuilder.Append($"allow-from: {AllowFromDomain};");
                     break;
             }
 

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A .NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
-    <VersionPrefix>3.0.0.0</VersionPrefix>
+    <VersionPrefix>3.0.0.1</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/tests/SecureHeadersInjectedTest.cs
+++ b/tests/SecureHeadersInjectedTest.cs
@@ -74,7 +74,7 @@ namespace tests
             if (headerPresentConfig.UseXFrameOptions)
             {
                 Assert.True(_context.Response.Headers.ContainsKey(Constants.XFrameOptionsHeaderName));
-                Assert.Equal("sameorigin", _context.Response.Headers[Constants.XFrameOptionsHeaderName]);
+                Assert.Equal("deny;", _context.Response.Headers[Constants.XFrameOptionsHeaderName]);
             }
         }
         
@@ -180,7 +180,7 @@ namespace tests
             if (headerPresentConfig.UseContentSecurityPolicy)
             {
                 Assert.True(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyHeaderName));
-                Assert.Equal("block-all-mixed-content; upgrade-insecure-requests; report-uri https://dotnetcore.gaprogman.com;",
+                Assert.Equal("script-src 'self';object-src 'self';block-all-mixed-content; upgrade-insecure-requests;",
                     _context.Response.Headers[Constants.ContentSecurityPolicyHeaderName]);
             }
             else


### PR DESCRIPTION
Fixes #16 and fixes #17

- Content Security Policy is now used correctly;
- Domains and directives within Content Security Policy are now used correctly in the rendered CSP header value;
- Updated version number of Middleware to reflect changes made.