### PR TITLE
Fix typos.

### DIFF
--- a/src/Enums/CspSandboxType.cs
+++ b/src/Enums/CspSandboxType.cs
@@ -5,7 +5,7 @@
         allowForms,
         allowModals,
         allowOrientationLock,
-        allowpPointerLock,
+        allowPointerLock,
         allowPopups,
         allowPopupsToEscapeSandbox,
         allowPresentation,

--- a/src/Extensions/ContentSecurityPolicyExtensions.cs
+++ b/src/Extensions/ContentSecurityPolicyExtensions.cs
@@ -10,7 +10,7 @@ namespace OwaspHeaders.Core.Extensions
         /// Used to set the Content Security Policy URIs for a given <see cref="CspUriType"/>
         /// </summary>
         public static SecureHeadersMiddlewareConfiguration SetCspUris
-            (this SecureHeadersMiddlewareConfiguration config, List<ContenSecurityPolicyElement> baseUri,
+            (this SecureHeadersMiddlewareConfiguration config, List<ContentSecurityPolicyElement> baseUri,
             CspUriType cspUriType)
         {
             if (config.UseContentSecurityPolicy)

--- a/src/Extensions/SecureHeadersMiddlewareBuilder.cs
+++ b/src/Extensions/SecureHeadersMiddlewareBuilder.cs
@@ -3,7 +3,7 @@
 //        page. The original comments can be found at:
 //                https://www.owasp.org/index.php/OWASP_Secure_Headers_Project
 // Note:  the description of the Expect-CT header (used above the UseExpectCt
-//        method is taken from the MDN page for the header, which can be found
+//        method) is taken from the MDN page for the header, which can be found
 //        at the following url:
 //          https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT
 
@@ -140,11 +140,11 @@ namespace OwaspHeaders.Core.Extensions
                 (null, true, true, null, null);
 
             config.SetCspUris(
-                new List<ContenSecurityPolicyElement> {ContentSecurityPolicyHelpers.CreateSelfDirective()},
+                new List<ContentSecurityPolicyElement> {ContentSecurityPolicyHelpers.CreateSelfDirective()},
                 CspUriType.Script);
 
             config.SetCspUris(
-                new List<ContenSecurityPolicyElement> {ContentSecurityPolicyHelpers.CreateSelfDirective()},
+                new List<ContentSecurityPolicyElement> {ContentSecurityPolicyHelpers.CreateSelfDirective()},
                 CspUriType.Object);
             
             return config;

--- a/src/Extensions/StringBuilderExtensions.cs
+++ b/src/Extensions/StringBuilderExtensions.cs
@@ -6,7 +6,7 @@ using OwaspHeaders.Core.Models;
 
 namespace OwaspHeaders.Core.Extensions
 {
-    public static class StringBuilderExtentions
+    public static class StringBuilderExtensions
     {
         /// <summary>
         /// Used to build the concatenated string value for the given values
@@ -16,7 +16,7 @@ namespace OwaspHeaders.Core.Extensions
         /// <param name="directiveValues">A list of strings representing the directive values</param>
         /// <returns>The updated <see cref="StringBuilder" /> instance</returns>
         public static StringBuilder BuildValuesForDirective(this StringBuilder @stringBuilder,
-            string directiveName, List<ContenSecurityPolicyElement> directiveValues)
+            string directiveName, List<ContentSecurityPolicyElement> directiveValues)
         {
             if (!directiveValues.Any()) return stringBuilder;
             

--- a/src/Helpers/ContentSecurityPolicyHelpers.cs
+++ b/src/Helpers/ContentSecurityPolicyHelpers.cs
@@ -11,12 +11,12 @@ namespace OwaspHeaders.Core.Helpers
         /// or to the 'default-src' rule to cover them all.
         /// </summary>
         /// <returns>
-        /// A new instance of the <see cref="ContenSecurityPolicyElement"/>
+        /// A new instance of the <see cref="ContentSecurityPolicyElement"/>
         /// class which represents a 'self' CSP rule.
         /// </returns>
-        public static ContenSecurityPolicyElement CreateSelfDirective()
+        public static ContentSecurityPolicyElement CreateSelfDirective()
         {
-            return new ContenSecurityPolicyElement
+            return new ContentSecurityPolicyElement
             {
                 CommandType = CspCommandType.Directive,
                 DirectiveOrUri = "self"

--- a/src/Models/ContentSecurityPolicyConfiguration.cs
+++ b/src/Models/ContentSecurityPolicyConfiguration.cs
@@ -11,72 +11,72 @@ namespace OwaspHeaders.Core.Models
         /// <summary>
         /// The base-uri values to use (which can be used in a document's base element)
         /// </summary>
-        public List<ContenSecurityPolicyElement> BaseUri { get; set; }
+        public List<ContentSecurityPolicyElement> BaseUri { get; set; }
 
         /// <summary>
         /// The default-src values to use (as a fallback for the other CSP rules)
         /// </summary>
-        public List<ContenSecurityPolicyElement> DefaultSrc { get; set; }
+        public List<ContentSecurityPolicyElement> DefaultSrc { get; set; }
 
         /// <summary>
         /// The script-src values to use (valid sources for sources for JavaScript)
         /// </summary>
-        public List<ContenSecurityPolicyElement> ScriptSrc { get; set; }
+        public List<ContentSecurityPolicyElement> ScriptSrc { get; set; }
 
         /// <summary>
         /// The object-src values to use (valid sources for the object, embed, and applet elements)
         /// </summary>
-        public List<ContenSecurityPolicyElement> ObjectSrc { get; set; }
+        public List<ContentSecurityPolicyElement> ObjectSrc { get; set; }
 
         /// <summary>
         /// The style-src values to use (valid sources for style sheets)
         /// </summary>
-        public List<ContenSecurityPolicyElement> StyleSrc { get; set; }
+        public List<ContentSecurityPolicyElement> StyleSrc { get; set; }
 
         /// <summary>
         /// The img-src values to use (valid sources for images and favicons)
         /// </summary>
-        public List<ContenSecurityPolicyElement> ImgSrc { get; set; }
+        public List<ContentSecurityPolicyElement> ImgSrc { get; set; }
 
         /// <summary>
         /// The media-src values to use (valid sources for loading media using the audio and video elements)
         /// </summary>
-        public List<ContenSecurityPolicyElement> MediaSrc { get; set; }
+        public List<ContentSecurityPolicyElement> MediaSrc { get; set; }
 
         /// <summary>
         /// The frame-src values to use (valid sources for nested browsing contexts loading using elements such as frame and iframe)
         /// </summary>
-        public List<ContenSecurityPolicyElement> FrameSrc { get; set; }
+        public List<ContentSecurityPolicyElement> FrameSrc { get; set; }
 
         /// <summary>
         /// The child-src values to use (valid sources for web workers and nested browsing contexts loaded using elements such as frame and iframe)
         /// </summary>
-        public List<ContenSecurityPolicyElement> ChildSrc { get; set; }
+        public List<ContentSecurityPolicyElement> ChildSrc { get; set; }
 
         /// <summary>
         /// The frame-ancestors values to use (valid parents that may embed a page using frame, iframe, object, embed, or applet)
         /// </summary>
-        public List<ContenSecurityPolicyElement> FrameAncestors { get; set; }
+        public List<ContentSecurityPolicyElement> FrameAncestors { get; set; }
 
         /// <summary>
         /// The font-src values to use (valid sources for fonts loaded using @font-face)
         /// </summary>
-        public List<ContenSecurityPolicyElement> FontSrc { get; set; }
+        public List<ContentSecurityPolicyElement> FontSrc { get; set; }
 
         /// <summary>
         /// The connect-src values to use (restricts the URLs which can be loaded using script interfaces)
         /// </summary>
-        public List<ContenSecurityPolicyElement> ConnectSrc { get; set; }
+        public List<ContentSecurityPolicyElement> ConnectSrc { get; set; }
 
         /// <summary>
         /// The manifest-src values to use (which manifest can be applied to the resource)
         /// </summary>
-        public List<ContenSecurityPolicyElement> ManifestSrc { get; set; }
+        public List<ContentSecurityPolicyElement> ManifestSrc { get; set; }
 
         /// <summary>
         /// The form-action values to use (restricts the URLs which can be used as the target of a form submissions from a given context)
         /// </summary>
-        public List<ContenSecurityPolicyElement> FormAction { get; set; }
+        public List<ContentSecurityPolicyElement> FormAction { get; set; }
         
         /// <summary>
         /// Specifies an HTML sandbox policy that the user agent applies to the protected resource.
@@ -113,20 +113,20 @@ namespace OwaspHeaders.Core.Models
         public ContentSecurityPolicyConfiguration(string pluginTypes, bool blockAllMixedContent,
             bool upgradeInsecureRequests, string referrer, string reportUri)
         {
-            BaseUri = new List<ContenSecurityPolicyElement>();
-            DefaultSrc = new List<ContenSecurityPolicyElement>();
-            ScriptSrc = new List<ContenSecurityPolicyElement>();
-            ObjectSrc = new List<ContenSecurityPolicyElement>();
-            StyleSrc = new List<ContenSecurityPolicyElement>();
-            ImgSrc = new List<ContenSecurityPolicyElement>();
-            MediaSrc = new List<ContenSecurityPolicyElement>();
-            FrameSrc = new List<ContenSecurityPolicyElement>();
-            ChildSrc = new List<ContenSecurityPolicyElement>();
-            FrameAncestors = new List<ContenSecurityPolicyElement>();
-            FontSrc = new List<ContenSecurityPolicyElement>();
-            ConnectSrc = new List<ContenSecurityPolicyElement>();
-            ManifestSrc = new List<ContenSecurityPolicyElement>();
-            FormAction = new List<ContenSecurityPolicyElement>();
+            BaseUri = new List<ContentSecurityPolicyElement>();
+            DefaultSrc = new List<ContentSecurityPolicyElement>();
+            ScriptSrc = new List<ContentSecurityPolicyElement>();
+            ObjectSrc = new List<ContentSecurityPolicyElement>();
+            StyleSrc = new List<ContentSecurityPolicyElement>();
+            ImgSrc = new List<ContentSecurityPolicyElement>();
+            MediaSrc = new List<ContentSecurityPolicyElement>();
+            FrameSrc = new List<ContentSecurityPolicyElement>();
+            ChildSrc = new List<ContentSecurityPolicyElement>();
+            FrameAncestors = new List<ContentSecurityPolicyElement>();
+            FontSrc = new List<ContentSecurityPolicyElement>();
+            ConnectSrc = new List<ContentSecurityPolicyElement>();
+            ManifestSrc = new List<ContentSecurityPolicyElement>();
+            FormAction = new List<ContentSecurityPolicyElement>();
 
             PluginTypes = pluginTypes;
             BlockAllMixedContent = blockAllMixedContent;

--- a/src/Models/ContentSecurityPolicyElement.cs
+++ b/src/Models/ContentSecurityPolicyElement.cs
@@ -2,7 +2,7 @@ using OwaspHeaders.Core.Enums;
 
 namespace OwaspHeaders.Core.Models
 {
-    public class ContenSecurityPolicyElement
+    public class ContentSecurityPolicyElement
     {
         public CspCommandType CommandType { get; set; }
         public string DirectiveOrUri { get; set; }

--- a/src/Models/ContentSecurityPolicyExtensions.cs
+++ b/src/Models/ContentSecurityPolicyExtensions.cs
@@ -4,13 +4,13 @@ using OwaspHeaders.Core.Helpers;
 
 namespace OwaspHeaders.Core.Models
 {
-    public static class ContentSecurityPolicyExtentions
+    public static class ContentSecurityPolicyExtensions
     {
         /// <summary>
         /// Used to set the Content Security Policy URIs for a given <see cref="CspUriType"/>
         /// </summary>
         public static ContentSecurityPolicyConfiguration SetCspUri
-            (this ContentSecurityPolicyConfiguration @this, List<ContenSecurityPolicyElement> uris,
+            (this ContentSecurityPolicyConfiguration @this, List<ContentSecurityPolicyElement> uris,
             CspUriType uriType)
         {
             switch (uriType)

--- a/src/Models/ContentSecurityPolicySandBox.cs
+++ b/src/Models/ContentSecurityPolicySandBox.cs
@@ -24,7 +24,7 @@ namespace OwaspHeaders.Core.Models
                     return $"{returnStr} allow-modals; ";
                 case CspSandboxType.allowOrientationLock:
                     return $"{returnStr} allow-orientation-lock; ";
-                case CspSandboxType.allowpPointerLock:
+                case CspSandboxType.allowPointerLock:
                     return $"{returnStr} allow-pointer-lock; ";
                 case CspSandboxType.allowPopups:
                     return $"{returnStr} allow-popups; ";


### PR DESCRIPTION
Fixed some typos in class, enum & property names. This is a breaking change as it affects public entities.