### PR TITLE
Blob star data encapsulated in quotes

### DIFF
--- a/src/Extensions/StringBuilderExtensions.cs
+++ b/src/Extensions/StringBuilderExtensions.cs
@@ -8,6 +8,13 @@ namespace OwaspHeaders.Core.Extensions
 {
     public static class StringBuilderExtensions
     {
+        private static List<string> UnquotedDirectiveValues = new List<string>
+        {
+            "blob", "*", "data"
+        };
+        
+        private static string EmptySpace = " ";
+
         /// <summary>
         /// Used to build the concatenated string value for the given values
         /// </summary>
@@ -23,16 +30,21 @@ namespace OwaspHeaders.Core.Extensions
             @stringBuilder.Append(directiveName);            
             if (directiveValues.Any(d => d.CommandType == CspCommandType.Directive))
             {
-                @stringBuilder.Append(" ");
-                @stringBuilder.Append(string.Join(" ",
-                    directiveValues.Where(command => (command.CommandType == CspCommandType.Directive))
-                        .Select(directive => $"'{directive.DirectiveOrUri}'")));
+                @stringBuilder.Append(EmptySpace);
+
+                var unquoted = directiveValues.Where(command => (command.CommandType == CspCommandType.Directive))
+                        .Where(directive => UnquotedDirectiveValues.Contains(directive.DirectiveOrUri));
+                var quoted = directiveValues.Except(unquoted);
+
+                @stringBuilder.Append(string.Join(EmptySpace, unquoted.Select(directive => directive.DirectiveOrUri)));
+                @stringBuilder.Append(EmptySpace);
+                @stringBuilder.Append(string.Join(EmptySpace, quoted.Select(directive => $"'{directive.DirectiveOrUri}'")));
             }
 
             if (directiveValues.Any(d => d.CommandType == CspCommandType.Uri))
             {
-                @stringBuilder.Append(" ");
-                @stringBuilder.Append(string.Join(" ",
+                @stringBuilder.Append(EmptySpace);
+                @stringBuilder.Append(string.Join(EmptySpace,
                     directiveValues.Where(command => (command.CommandType == CspCommandType.Uri))
                         .Select(e => e.DirectiveOrUri)));
             }

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A .NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
-    <VersionPrefix>3.4.1</VersionPrefix>
+    <VersionPrefix>3.5.0</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/OwaspHeadersCore.nuspec
+++ b/src/OwaspHeadersCore.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>OwaspHeaders.Core</id>
-    <version>3.4.1</version>
+    <version>3.5.0</version>
     <authors>GaProgMan</authors>
     <owners>GaProgMan</owners>
     <licenseUrl>https://github.com/GaProgMan/OwaspHeaders.Core/blob/master/LICENSE</licenseUrl>
@@ -13,7 +13,7 @@
     <tags>OWASP Http-headers Security ASP-NET-Core Middleware</tags>
     <dependencies>
       <group targetFramework="netstandard2.0">
-      <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="2.0.0" />
+      <dependency id="Microsoft.AspNetCore.Http.Abstractions" version="2.1.1" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
This pull request fixes #39.

The code for preparing CSP directives now looks for known specific keywords (`blob`, `*`, and `data`) before preparing the CSP directive string, and adds them without quotes FIRST.

The decision was made to add these first, as they are wild-card (ish) and subsequent directives may help to further filter sources added by these.