### PR TITLE
Report uri optional

### DIFF
--- a/src/Extensions/SecureHeadersMiddlewareBuilder.cs
+++ b/src/Extensions/SecureHeadersMiddlewareBuilder.cs
@@ -253,12 +253,6 @@ namespace OwaspHeaders.Core.Extensions
                 string reportUri, int maxAge = 86400, bool enforce = false)
         {
             config.UseExpectCt = true;
-
-            if (string.IsNullOrWhiteSpace(reportUri))
-            {
-                throw new ArgumentException($"Must supply value of {nameof(reportUri)} in {nameof(SecureHeadersMiddleware)}");
-            }
-            
             config.ExpectCt = new ExpectCt(reportUri, maxAge, enforce);
             return config;
         }

--- a/src/Extensions/SecureHeadersMiddlewareExtensions.cs
+++ b/src/Extensions/SecureHeadersMiddlewareExtensions.cs
@@ -31,7 +31,7 @@ namespace OwaspHeaders.Core.Extensions
                 .UseContentDefaultSecurityPolicy()
                 .UsePermittedCrossDomainPolicies()
                 .UseReferrerPolicy()
-                .UseExpectCt("https://gaprogman.com/report", enforce:true)
+                .UseExpectCt(string.Empty, enforce:true)
                 .RemovePoweredByHeader()
                 .Build();
         }

--- a/src/Models/ExpectCt.cs
+++ b/src/Models/ExpectCt.cs
@@ -61,8 +61,11 @@ namespace OwaspHeaders.Core.Models
             {
                 stringBuilder.Append(", enforce");
             }
-            stringBuilder.Append(", report-uri=");
-            stringBuilder.Append($"\"{ReportUri}\"");
+            if (!string.IsNullOrWhiteSpace(ReportUri))
+            {
+                stringBuilder.Append(", report-uri=");
+                stringBuilder.Append($"\"{ReportUri}\"");
+            }
 
             return stringBuilder.ToString();
         }

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A .NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
-    <VersionPrefix>3.5.0</VersionPrefix>
+    <VersionPrefix>3.5.1</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/OwaspHeadersCore.nuspec
+++ b/src/OwaspHeadersCore.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>OwaspHeaders.Core</id>
-    <version>3.5.0</version>
+    <version>3.5.1</version>
     <authors>GaProgMan</authors>
     <owners>GaProgMan</owners>
     <licenseUrl>https://github.com/GaProgMan/OwaspHeaders.Core/blob/master/LICENSE</licenseUrl>

--- a/tests/SecureHeadersInjectedTest.cs
+++ b/tests/SecureHeadersInjectedTest.cs
@@ -299,6 +299,26 @@ namespace tests
         }
 
         [Fact]
+        public async Task Invoke_ExpectCtHeaderName_HeaderIsPresent_ReportUri_Optional()
+        {
+            // arrange
+            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
+                .UseExpectCt(string.Empty).Build();
+            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+            // act
+            await secureHeadersMiddleware.Invoke(_context);
+            
+            // assert
+            if (headerPresentConfig.UseExpectCt)
+            {
+                Assert.True(_context.Response.Headers.ContainsKey(Constants.ExpectCtHeaderName));
+                Assert.Equal(headerPresentConfig.ExpectCt.BuildHeaderValue(),
+                    _context.Response.Headers[Constants.ExpectCtHeaderName]);
+            }
+        }
+
+        [Fact]
         public async Task Invoke_ExpectCtHeaderName_HeaderIsNotPresent()
         {
             // arrange


### PR DESCRIPTION
This PR fixes #37 

As pointed out in the issue, The Report-Uri field for the ExpectCT header is optional. The code base was throwing an exception when a Report-Uri value was not supplied, this is no longer the case. Also present was a hard-coded default Report-Uri which has been dropped.

There is now a unit test specifically to check that the Report-Uri is optional.