### PR TITLE
Hotfix/fix for extra spaces in csp directives

### DIFF
--- a/src/Extensions/StringBuilderExtensions.cs
+++ b/src/Extensions/StringBuilderExtensions.cs
@@ -36,9 +36,15 @@ namespace OwaspHeaders.Core.Extensions
                         .Where(directive => UnquotedDirectiveValues.Contains(directive.DirectiveOrUri));
                 var quoted = directiveValues.Except(unquoted);
 
-                @stringBuilder.Append(string.Join(EmptySpace, unquoted.Select(directive => directive.DirectiveOrUri)));
-                @stringBuilder.Append(EmptySpace);
-                @stringBuilder.Append(string.Join(EmptySpace, quoted.Select(directive => $"'{directive.DirectiveOrUri}'")));
+                if (unquoted.Any())
+                {
+                    @stringBuilder.Append(string.Join(EmptySpace, unquoted.Select(directive => directive.DirectiveOrUri)));
+                    @stringBuilder.Append(EmptySpace);
+                }
+                if (quoted.Any())
+                {
+                    @stringBuilder.Append(string.Join(EmptySpace, quoted.Select(directive => $"'{directive.DirectiveOrUri}'")));
+                }
             }
 
             if (directiveValues.Any(d => d.CommandType == CspCommandType.Uri))

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A .NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
-    <VersionPrefix>3.5.1</VersionPrefix>
+    <VersionPrefix>3.5.2</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/OwaspHeadersCore.nuspec
+++ b/src/OwaspHeadersCore.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>OwaspHeaders.Core</id>
-    <version>3.5.1</version>
+    <version>3.5.2</version>
     <authors>GaProgMan</authors>
     <owners>GaProgMan</owners>
     <licenseUrl>https://github.com/GaProgMan/OwaspHeaders.Core/blob/master/LICENSE</licenseUrl>


### PR DESCRIPTION
This hotfix fixes a state with broken unit tests due to commit a92db361b7362a0857fa99f33d75d462da7e2883 where extra spaces where added in the generated CSP directives.