### PR TITLE
Added a test which verifies that the config must not be null

### DIFF
--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A .NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <VersionPrefix>4.0.1</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/OwaspHeadersCore.nuspec
+++ b/src/OwaspHeadersCore.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>OwaspHeaders.Core</id>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <authors>GaProgMan</authors>
     <owners>GaProgMan</owners>
     <licenseUrl>https://github.com/GaProgMan/OwaspHeaders.Core/blob/master/LICENSE</licenseUrl>

--- a/tests/SecureHeadersInjectedTest.cs
+++ b/tests/SecureHeadersInjectedTest.cs
@@ -177,6 +177,21 @@ namespace tests
         }
 
         [Fact]
+        public async Task invoke_NullConfig_ExceptionThrown()
+        {
+            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, null);
+
+            var exception = await Record.ExceptionAsync(() => secureHeadersMiddleware.Invoke(_context));
+            
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<ArgumentException>(exception);
+            
+            var argEx = exception as ArgumentException;
+            Assert.NotNull(argEx);
+            Assert.Contains(nameof(SecureHeadersMiddlewareConfiguration), exception.Message);
+        }
+        
+        [Fact]
         public async Task Invoke_ContentSecurityPolicyHeaderName_HeaderIsPresent_WithMultipleCspSandboxTypes()
         {
             // arrange


### PR DESCRIPTION
OwaspHeaders.Core project now has 100% test coverage - will need to revisit these later