### PR TITLE
Added missing Cache-Control directives

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,37 @@ It was noticed that the `server:` header was not removed (this is defaulted to `
 
 It was [requested](https://github.com/GaProgMan/OwaspHeaders.Core/issues/60) that a `Content-Security-Policy-Report-Only` header could be added. This header was added in version 4.0.2 of the library.
 
+#### Version 4.4.0 Specific Changes
+
+The beginnings of the Cache-Control header were added via a [PR](https://github.com/GaProgMan/OwaspHeaders.Core/pull/63). This PR was sent in via GitHub user [mkokabi](https://github.com/mkokabi).
+
+#### Version 4.5.0 Specific Changes
+
+It was pointed out that the Cache-Control header PR was incomplete, and caused production systems to begin caching responses which should not have been cached. This version brings in a configuration for the Cache-Control header which allows the user to add the following directives:
+
+- `no-cache`
+- `no-store`
+- `must-revalidate`
+
+These directives are added when building the configuration:
+
+```c#
+return SecureHeadersMiddlewareBuilder
+    .CreateBuilder()
+    .UseHsts()
+    .UseXFrameOptions()
+    .UseContentTypeOptions()
+    .UseContentDefaultSecurityPolicy()
+    .UsePermittedCrossDomainPolicies()
+    .UseReferrerPolicy()
+    .UseCacheControl() // <- this line
+    .UseExpectCt(string.Empty, enforce: true)
+    .RemovePoweredByHeader()
+    .Build();
+```
+
+The above directives are added via `bool`s. For example, in order to add the `no-cache` header, you need to alter the call to `UseCacheControl()` to look like `UseCacheControl(noCache: true)`.
+
 ### Version 3
 
 This version of the repo removed the dependency on .NET Core 2.0, and replaced it with a dependency on .NET Standard 2.0 (via the `netstandard2.0` Target Framework Moniker), and the version of the [Microsoft.AspNetCore.Http.Abstractions](https://www.nuget.org/packages/Microsoft.AspNetCore.Http.Abstractions/) was upped to version 2.1.1

--- a/example/Program.cs
+++ b/example/Program.cs
@@ -1,4 +1,3 @@
-using OwaspHeaders.Core.Enums;
 using OwaspHeaders.Core.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/src/Extensions/SecureHeadersMiddlewareBuilder.cs
+++ b/src/Extensions/SecureHeadersMiddlewareBuilder.cs
@@ -267,10 +267,11 @@ namespace OwaspHeaders.Core.Extensions
         /// </exception>
         public static SecureHeadersMiddlewareConfiguration UseCacheControl
         (this SecureHeadersMiddlewareConfiguration config,
-            bool @private = true, int maxAge = 31536000)
+            bool @private = true, int maxAge = 31536000, bool noCache = false, bool noStore = false,
+            bool mustRevalidate = false)
         {
             config.UseCacheControl = true;
-            config.CacheControl = new CacheControl(@private, maxAge);
+            config.CacheControl = new CacheControl(@private, maxAge, noCache, noStore, mustRevalidate);
             return config;
         }
 

--- a/src/Models/CacheControl.cs
+++ b/src/Models/CacheControl.cs
@@ -1,16 +1,23 @@
-﻿using System.Collections.Generic;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using OwaspHeaders.Core.Enums;
-using OwaspHeaders.Core.Helpers;
 
 namespace OwaspHeaders.Core.Models
 {
+    /// <summary>
+    /// This class represents some of the most commonly used Cache Control directives. For more information on this
+    /// header, please see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+    /// </summary>
     public class CacheControl : IConfigurationBase
     {
         /// <summary>
         /// Whether all or part of the HTTP response message is intended for a single user and must 
         /// not be cached by a shared cache.
         /// </summary>
+        /// The following is taken from the MDN article for cache-control
+        ///    If you forget to add private to a response with personalized content, then that response can be stored in
+        ///    a shared cache and end up being reused for multiple users, which can cause personal information to leak.
+        /// Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#private
+        /// </remarks>
         public bool Private { get; set; }
 
         /// <summary>
@@ -19,15 +26,46 @@ namespace OwaspHeaders.Core.Models
         public int MaxAge { get; set; }
 
         /// <summary>
+        /// Represents whether the response can be cached. If the response cannot be cached, then the origin server
+        /// must be contacted for every request.
+        /// </summary>
+        /// <remarks>
+        /// The following is taken from the MDN article for cache-control
+        ///   Note that no-cache does not mean "don't cache". no-cache allows caches to store a response but requires
+        ///   them to revalidate it before reuse. If the sense of "don't cache" that you want is actually "don't store",
+        ///   then no-store is the directive to use.
+        /// Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#no-cache
+        /// </remarks>
+        public bool NoCache { get; set; }
+
+        /// <summary>
+        /// Represents whether the response can be stored in caches and used whilst still fresh
+        /// </summary>
+        /// <remarks>
+        /// This is used alongside the MaxAge directive
+        /// </remarks>
+        public bool MustRevalidate { get; set; }
+
+        /// <summary>
+        ///  Represents whether the response can be stored anywhere (i.e. either public or private caches)
+        /// </summary>
+        public bool NoStore { get; set; }
+
+        /// <summary>
         /// Protected constructor, we can no longer create instances of this
         /// class without using the public constructor
         /// </summary>
+        [ExcludeFromCodeCoverage]
         protected CacheControl() { }
 
-        public CacheControl(bool @private, int maxAge = 86400)
+        public CacheControl(bool @private, int maxAge = 86400, bool noCache = false, bool noStore = false,
+            bool mustRevalidate = false)
         {
             Private = @private;
             MaxAge = maxAge;
+            NoCache = noCache;
+            NoStore = noStore;
+            MustRevalidate = mustRevalidate;
         }
 
         /// <summary>
@@ -37,8 +75,25 @@ namespace OwaspHeaders.Core.Models
         public string BuildHeaderValue()
         {
             var stringBuilder = new StringBuilder();
+            if (NoCache)
+            {
+                stringBuilder.Append("no-cache");
+                return stringBuilder.ToString();
+            }
+
+            if (NoStore)
+            {
+                stringBuilder.Append("no-store");
+                return stringBuilder.ToString();
+            }
+
             stringBuilder.Append("max-age=");
             stringBuilder.Append(MaxAge);
+            if (MustRevalidate)
+            {
+                stringBuilder.Append(", must-revalidate");
+            }
+
             if (Private)
             {
                 stringBuilder.Append(", private");

--- a/src/Models/ContentSecurityPolicyConfiguration.cs
+++ b/src/Models/ContentSecurityPolicyConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using OwaspHeaders.Core.Extensions;

--- a/src/Models/ContentSecurityPolicySandBox.cs
+++ b/src/Models/ContentSecurityPolicySandBox.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using OwaspHeaders.Core.Enums;
 

--- a/src/Models/ExpectCt.cs
+++ b/src/Models/ExpectCt.cs
@@ -3,10 +3,7 @@
 // Full details can be found at the folloing url:
 // https://scotthelme.co.uk/a-new-security-header-expect-ct/
 
-using System.Collections.Generic;
 using System.Text;
-using OwaspHeaders.Core.Enums;
-using OwaspHeaders.Core.Helpers;
 
 namespace OwaspHeaders.Core.Models
 {

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A .NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
-    <VersionPrefix>4.4.0</VersionPrefix>
+    <VersionPrefix>4.5.0</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/tests/CacheControlHeaderOptionsTests.cs
+++ b/tests/CacheControlHeaderOptionsTests.cs
@@ -1,0 +1,115 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using OwaspHeaders.Core;
+using OwaspHeaders.Core.Extensions;
+using Xunit;
+
+namespace tests;
+
+public class CacheControlHeaderOptionsTests
+{
+    private int _onNextCalledTimes;
+    private readonly Task _onNextResult = Task.FromResult(0);
+    private readonly RequestDelegate _onNext;
+    private readonly DefaultHttpContext _context;
+
+    public CacheControlHeaderOptionsTests()
+    {
+        _onNext = _ =>
+        {
+            Interlocked.Increment(ref _onNextCalledTimes);
+            return _onNextResult;
+        };
+        _context = new DefaultHttpContext();
+    }
+        
+    [Fact]
+    public async Task Invoke_CacheControl_IsPrivate_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
+            .UseCacheControl(@private: true).Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.Invoke(_context);
+
+        // assert
+        Assert.True(headerPresentConfig.UseCacheControl);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.CacheControlHeaderName));
+
+        _context.Response.Headers.TryGetValue(Constants.CacheControlHeaderName, out var headerValues);
+        Assert.True(headerValues.Any());
+        Assert.Contains("private", headerValues.First());
+        Assert.DoesNotContain("no-cache", headerValues.First());
+        Assert.DoesNotContain("no-store", headerValues.First());
+    }
+        
+    [Fact]
+    public async Task Invoke_CacheControl_MustRevalidate_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
+            .UseCacheControl(mustRevalidate: true).Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.Invoke(_context);
+
+        // assert
+        Assert.True(headerPresentConfig.UseCacheControl);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.CacheControlHeaderName));
+
+        _context.Response.Headers.TryGetValue(Constants.CacheControlHeaderName, out var headerValues);
+        Assert.True(headerValues.Any());
+        Assert.Contains("must-revalidate", headerValues.First());
+        Assert.DoesNotContain("no-cache", headerValues.First());
+        Assert.DoesNotContain("no-store", headerValues.First());
+    }
+        
+    [Fact]
+    public async Task Invoke_CacheControl_NoCache_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
+            .UseCacheControl(noCache: true).Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.Invoke(_context);
+
+        // assert
+        Assert.True(headerPresentConfig.UseCacheControl);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.CacheControlHeaderName));
+
+        _context.Response.Headers.TryGetValue(Constants.CacheControlHeaderName, out var headerValues);
+        Assert.True(headerValues.Any());
+        Assert.Contains("no-cache", headerValues.First());
+        Assert.DoesNotContain("private", headerValues.First());
+        Assert.DoesNotContain("must-revalidate", headerValues.First());
+    }
+        
+    [Fact]
+    public async Task Invoke_CacheControl_NoStore_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
+            .UseCacheControl(noStore: true).Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.Invoke(_context);
+
+        // assert
+        Assert.True(headerPresentConfig.UseCacheControl);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.CacheControlHeaderName));
+
+        _context.Response.Headers.TryGetValue(Constants.CacheControlHeaderName, out var headerValues);
+        Assert.True(headerValues.Any());
+        Assert.Contains("no-store", headerValues.First());
+        Assert.DoesNotContain("private", headerValues.First());
+        Assert.DoesNotContain("must-revalidate", headerValues.First());
+    }
+}

--- a/tests/SecureHeadersInjectedTest.cs
+++ b/tests/SecureHeadersInjectedTest.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Primitives;
 using OwaspHeaders.Core;
 using OwaspHeaders.Core.Enums;
 using OwaspHeaders.Core.Extensions;


### PR DESCRIPTION
A number of missing Cache-Control directives have been added in this PR. The Cache-Control directives added in this PR are:

- `no-cache`
- `no-store`
- `must-revalidate`

Tests which validate the options supplied for the creation of Cache-Control directives have been also added.