### PR TITLE
Fix #61

### DIFF
--- a/src/Extensions/StringBuilderExtensions.cs
+++ b/src/Extensions/StringBuilderExtensions.cs
@@ -47,20 +47,13 @@ namespace OwaspHeaders.Core.Extensions
             stringBuilder.Append(directiveName);
             if (directiveValues.Any(d => d.CommandType == CspCommandType.Directive))
             {
-
                 var directives = directiveValues.Where(command => command.CommandType == CspCommandType.Directive);
-                var uris = directiveValues.Where(command => command.CommandType == CspCommandType.Uri);
-
                 stringBuilder.Append(EmptySpace);
 
                 if (directives.Any())
                 {
                     stringBuilder.Append(string.Join(EmptySpace, directives.Select(directive => $"'{directive.DirectiveOrUri}'")));
                     stringBuilder.Append(EmptySpace);
-                }
-                if (uris.Any())
-                {
-                    stringBuilder.Append(string.Join(EmptySpace, uris.Select(directive => directive.DirectiveOrUri)));
                 }
             }
 

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>A .NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
-    <VersionPrefix>4.5.1</VersionPrefix>
+    <VersionPrefix>4.6.0</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/SecureHeadersMiddleware.cs
+++ b/src/SecureHeadersMiddleware.cs
@@ -27,7 +27,7 @@ namespace OwaspHeaders.Core
         /// </summary>
         /// <param name="httpContext">The <see cref="HttpContext" /> for the current request or response</param>
         /// <returns></returns>
-        public async Task Invoke(HttpContext httpContext)
+        public async Task InvokeAsync(HttpContext httpContext)
         {
             if (_config == null)
             {
@@ -106,7 +106,7 @@ namespace OwaspHeaders.Core
             }
 
             // Call the next middleware in the chain
-            await _next.Invoke(httpContext);
+            await _next(httpContext);
         }
     }
 }

--- a/tests/CacheControlHeaderOptionsTests.cs
+++ b/tests/CacheControlHeaderOptionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -8,6 +9,7 @@ using Xunit;
 
 namespace tests;
 
+[ExcludeFromCodeCoverage]
 public class CacheControlHeaderOptionsTests
 {
     private int _onNextCalledTimes;
@@ -34,7 +36,7 @@ public class CacheControlHeaderOptionsTests
         var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
 
         // act
-        await secureHeadersMiddleware.Invoke(_context);
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
         // assert
         Assert.True(headerPresentConfig.UseCacheControl);
@@ -56,7 +58,7 @@ public class CacheControlHeaderOptionsTests
         var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
 
         // act
-        await secureHeadersMiddleware.Invoke(_context);
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
         // assert
         Assert.True(headerPresentConfig.UseCacheControl);
@@ -78,7 +80,7 @@ public class CacheControlHeaderOptionsTests
         var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
 
         // act
-        await secureHeadersMiddleware.Invoke(_context);
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
         // assert
         Assert.True(headerPresentConfig.UseCacheControl);
@@ -100,7 +102,7 @@ public class CacheControlHeaderOptionsTests
         var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
 
         // act
-        await secureHeadersMiddleware.Invoke(_context);
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
         // assert
         Assert.True(headerPresentConfig.UseCacheControl);

--- a/tests/RegressionTests.cs
+++ b/tests/RegressionTests.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using OwaspHeaders.Core;
+using OwaspHeaders.Core.Enums;
+using OwaspHeaders.Core.Extensions;
+using OwaspHeaders.Core.Models;
+using Xunit;
+
+namespace tests;
+
+/// <summary>
+/// This class contains a number of regression tests against bugs which were reported
+/// using GitHub issues. Each test will link to the issue in question. Please make sure
+/// that these tests still pass whenever making changes to this codebase
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class RegressionTests
+{
+    private int _onNextCalledTimes;
+    private readonly Task _onNextResult = Task.FromResult(0);
+    private readonly RequestDelegate _onNext;
+    private readonly DefaultHttpContext _context;
+
+    public RegressionTests()
+    {
+        _onNext = _ =>
+        {
+            Interlocked.Increment(ref _onNextCalledTimes);
+            return _onNextResult;
+        };
+        _context = new DefaultHttpContext();
+    }
+
+    /// <summary>
+    /// This test exercises and provides regression against https://github.com/GaProgMan/OwaspHeaders.Core/issues/61
+    /// </summary>
+    [Fact]
+    public async Task ContentSecurityPolicy_Adds_MultipleSameValue()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseContentSecurityPolicy()
+            .SetCspUris(
+                new List<ContentSecurityPolicyElement>
+                {
+                    new()
+                    {
+                        CommandType = CspCommandType.Directive, DirectiveOrUri = "self"
+                    },
+                    new()
+                    {
+                        CommandType = CspCommandType.Uri, DirectiveOrUri = "cdnjs.cloudflare.com"
+                    }
+                }, CspUriType.Style).Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyHeaderName));
+
+        var headerValue = _context.Response.Headers[Constants.ContentSecurityPolicyHeaderName].ToList();
+        Assert.Equal(1,
+            headerValue.First()
+                .Split(" ")
+                .Count(hv => hv.Contains("cdnjs.cloudflare.com", StringComparison.InvariantCultureIgnoreCase)));
+    }
+}
+

--- a/tests/SecureHeadersInjectedTest.cs
+++ b/tests/SecureHeadersInjectedTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -8,470 +9,470 @@ using OwaspHeaders.Core.Extensions;
 using OwaspHeaders.Core.Models;
 using Xunit;
 
-namespace tests
+namespace tests;
+
+[ExcludeFromCodeCoverage]
+public class SecureHeadersInjectedTest
 {
-    public class SecureHeadersInjectedTest
+    private int _onNextCalledTimes;
+    private readonly Task _onNextResult = Task.FromResult(0);
+    private readonly RequestDelegate _onNext;
+    private readonly DefaultHttpContext _context;
+
+    public SecureHeadersInjectedTest()
     {
-        private int _onNextCalledTimes;
-        private readonly Task _onNextResult = Task.FromResult(0);
-        private readonly RequestDelegate _onNext;
-        private readonly DefaultHttpContext _context;
-
-        public SecureHeadersInjectedTest()
+        _onNext = _ =>
         {
-            _onNext = _ =>
-            {
-                Interlocked.Increment(ref _onNextCalledTimes);
-                return _onNextResult;
-            };
-            _context = new DefaultHttpContext();
-        }
+            Interlocked.Increment(ref _onNextCalledTimes);
+            return _onNextResult;
+        };
+        _context = new DefaultHttpContext();
+    }
 
-        [Fact]
-        public async Task Invoke_StrictTransportSecurityHeaderName_HeaderIsPresent()
+    [Fact]
+    public async Task Invoke_StrictTransportSecurityHeaderName_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseHsts().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.True(headerPresentConfig.UseHsts);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.StrictTransportSecurityHeaderName));
+        Assert.Equal("max-age=63072000;includeSubDomains",
+            _context.Response.Headers[Constants.StrictTransportSecurityHeaderName]);
+    }
+
+    [Fact]
+    public async Task Invoke_StrictTransportSecurityHeaderName_HeaderIsNotPresent()
+    {
+        // arrange
+        var headerNotPresetConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresetConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.False(headerNotPresetConfig.UseHsts);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.StrictTransportSecurityHeaderName));
+    }
+
+    [Fact]
+    public async Task Invoke_XFrameOptionsHeaderName_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseXFrameOptions().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.True(headerPresentConfig.UseXFrameOptions);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.XFrameOptionsHeaderName));
+        Assert.Equal("DENY", _context.Response.Headers[Constants.XFrameOptionsHeaderName]);
+    }
+
+    [Fact]
+    public async Task Invoke_XFrameOptionsHeaderName_HeaderIsNotPresentInDefault()
+    {
+        // arrange
+        var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.False(headerNotPresentConfig.UseXFrameOptions);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.XFrameOptionsHeaderName));
+    }
+
+    [Fact]
+    public async Task Invoke_XssProtectionHeaderName_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseXSSProtection().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.True(headerPresentConfig.UseXssProtection);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.XssProtectionHeaderName));
+        Assert.Equal("1;mode=block", _context.Response.Headers[Constants.XssProtectionHeaderName]);
+    }
+
+    [Fact]
+    public async Task Invoke_XssProtectionHeaderName_HeaderIsNotPresent()
+    {
+        // arrange
+        var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.False(headerNotPresentConfig.UseXssProtection);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.XssProtectionHeaderName));
+    }
+
+
+    [Fact]
+    public async Task Invoke_XContentTypeOptionsHeaderName_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseContentTypeOptions().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.True(headerPresentConfig.UseXContentTypeOptions);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.XContentTypeOptionsHeaderName));
+        Assert.Equal("nosniff", _context.Response.Headers[Constants.XContentTypeOptionsHeaderName]);
+    }
+
+    [Fact]
+    public async Task Invoke_XContentTypeOptionsHeaderName_HeaderIsNotPresent()
+    {
+        // arrange
+        var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.False(headerNotPresentConfig.UseXContentTypeOptions);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.XContentTypeOptionsHeaderName));
+    }
+
+    [Fact]
+    public async Task Invoke_ContentSecurityPolicyHeaderName_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseContentDefaultSecurityPolicy().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        if (headerPresentConfig.UseContentSecurityPolicy)
         {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseHsts().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
-
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
-
-            // assert
-            Assert.True(headerPresentConfig.UseHsts);
-            Assert.True(_context.Response.Headers.ContainsKey(Constants.StrictTransportSecurityHeaderName));
-            Assert.Equal("max-age=63072000;includeSubDomains",
-                _context.Response.Headers[Constants.StrictTransportSecurityHeaderName]);
-        }
-
-        [Fact]
-        public async Task Invoke_StrictTransportSecurityHeaderName_HeaderIsNotPresent()
-        {
-            // arrange
-            var headerNotPresetConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresetConfig);
-
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
-
-            // assert
-            Assert.False(headerNotPresetConfig.UseHsts);
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.StrictTransportSecurityHeaderName));
-        }
-
-        [Fact]
-        public async Task Invoke_XFrameOptionsHeaderName_HeaderIsPresent()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseXFrameOptions().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
-
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
-
-            // assert
-            Assert.True(headerPresentConfig.UseXFrameOptions);
-            Assert.True(_context.Response.Headers.ContainsKey(Constants.XFrameOptionsHeaderName));
-            Assert.Equal("DENY", _context.Response.Headers[Constants.XFrameOptionsHeaderName]);
-        }
-
-        [Fact]
-        public async Task Invoke_XFrameOptionsHeaderName_HeaderIsNotPresentInDefault()
-        {
-            // arrange
-            var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
-
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
-
-            // assert
-            Assert.False(headerNotPresentConfig.UseXFrameOptions);
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.XFrameOptionsHeaderName));
-        }
-
-        [Fact]
-        public async Task Invoke_XssProtectionHeaderName_HeaderIsPresent()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseXSSProtection().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
-
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
-
-            // assert
-            Assert.True(headerPresentConfig.UseXssProtection);
-            Assert.True(_context.Response.Headers.ContainsKey(Constants.XssProtectionHeaderName));
-            Assert.Equal("1;mode=block", _context.Response.Headers[Constants.XssProtectionHeaderName]);
-        }
-
-        [Fact]
-        public async Task Invoke_XssProtectionHeaderName_HeaderIsNotPresent()
-        {
-            // arrange
-            var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
-
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
-
-            // assert
-            Assert.False(headerNotPresentConfig.UseXssProtection);
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.XssProtectionHeaderName));
-        }
-
-
-        [Fact]
-        public async Task Invoke_XContentTypeOptionsHeaderName_HeaderIsPresent()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseContentTypeOptions().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
-
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
-
-            // assert
-            Assert.True(headerPresentConfig.UseXContentTypeOptions);
-            Assert.True(_context.Response.Headers.ContainsKey(Constants.XContentTypeOptionsHeaderName));
-            Assert.Equal("nosniff", _context.Response.Headers[Constants.XContentTypeOptionsHeaderName]);
-        }
-
-        [Fact]
-        public async Task Invoke_XContentTypeOptionsHeaderName_HeaderIsNotPresent()
-        {
-            // arrange
-            var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
-
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
-
-            // assert
-            Assert.False(headerNotPresentConfig.UseXContentTypeOptions);
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.XContentTypeOptionsHeaderName));
-        }
-
-        [Fact]
-        public async Task Invoke_ContentSecurityPolicyHeaderName_HeaderIsPresent()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseContentDefaultSecurityPolicy().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
-
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
-
-            // assert
-            if (headerPresentConfig.UseContentSecurityPolicy)
-            {
-                Assert.True(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyHeaderName));
-                Assert.Equal("script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests;",
-                    _context.Response.Headers[Constants.ContentSecurityPolicyHeaderName]);
-            }
-            else
-            {
-                Assert.False(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyHeaderName));
-            }
-        }
-
-        [Fact]
-        public async Task invoke_NullConfig_ExceptionThrown()
-        {
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, null);
-
-            var exception = await Record.ExceptionAsync(() => secureHeadersMiddleware.Invoke(_context));
-
-            Assert.NotNull(exception);
-            Assert.IsAssignableFrom<ArgumentException>(exception);
-
-            var argEx = exception as ArgumentException;
-            Assert.NotNull(argEx);
-            Assert.Contains(nameof(SecureHeadersMiddlewareConfiguration), exception.Message);
-        }
-
-        [Fact]
-        public async Task Invoke_ContentSecurityPolicyHeaderName_HeaderIsPresent_WithMultipleCspSandboxTypes()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseContentSecurityPolicy().Build();
-            headerPresentConfig.SetCspSandBox(CspSandboxType.allowForms, CspSandboxType.allowScripts, CspSandboxType.allowSameOrigin);
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
-
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
-
-            // assert
             Assert.True(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyHeaderName));
-            Assert.Equal("sandbox allow-forms allow-scripts allow-same-origin;block-all-mixed-content;upgrade-insecure-requests;",
+            Assert.Equal("script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests;",
                 _context.Response.Headers[Constants.ContentSecurityPolicyHeaderName]);
         }
-
-        [Fact]
-        public async Task Invoke_ContentSecurityPolicyHeaderName_HeaderIsNotPresent()
+        else
         {
-            // arrange
-            var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
-
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
-
-            // assert
-            Assert.False(headerNotPresentConfig.UseContentSecurityPolicy);
             Assert.False(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyHeaderName));
         }
+    }
 
-        [Fact]
-        public async Task Invoke_ContentSecurityPolicyReportOnly_HeaderIsPresent_WithMultipleCspSandboxTypes()
-        {
-            const string reportUri = "https://localhost:5001/report-uri";
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseContentSecurityPolicyReportOnly(reportUri).Build();
-            headerPresentConfig.SetCspSandBox(CspSandboxType.allowForms, CspSandboxType.allowScripts, CspSandboxType.allowSameOrigin);
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+    [Fact]
+    public async Task invoke_NullConfig_ExceptionThrown()
+    {
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, null);
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+        var exception = await Record.ExceptionAsync(() => secureHeadersMiddleware.InvokeAsync(_context));
 
-            // assert
-            Assert.True(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyReportOnlyHeaderName));
-            Assert.Equal($"block-all-mixed-content;upgrade-insecure-requests;report-uri {reportUri};",
-                _context.Response.Headers[Constants.ContentSecurityPolicyReportOnlyHeaderName]);
-        }
+        Assert.NotNull(exception);
+        Assert.IsAssignableFrom<ArgumentException>(exception);
 
-        [Fact]
-        public async Task Invoke_ContentSecurityPolicyReportOnly_HeaderIsNotPresent()
-        {
-            // arrange
-            var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
+        var argEx = exception as ArgumentException;
+        Assert.NotNull(argEx);
+        Assert.Contains(nameof(SecureHeadersMiddlewareConfiguration), exception.Message);
+    }
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+    [Fact]
+    public async Task Invoke_ContentSecurityPolicyHeaderName_HeaderIsPresent_WithMultipleCspSandboxTypes()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseContentSecurityPolicy().Build();
+        headerPresentConfig.SetCspSandBox(CspSandboxType.allowForms, CspSandboxType.allowScripts, CspSandboxType.allowSameOrigin);
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
 
-            // assert
-            Assert.False(headerNotPresentConfig.UseContentSecurityPolicyReportOnly);
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyReportOnlyHeaderName));
-        }
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-        [Fact]
-        public async Task Invoke_XContentSecurityPolicyHeaderName_HeaderIsPresent()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseContentSecurityPolicy(useXContentSecurityPolicy: true).Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+        // assert
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyHeaderName));
+        Assert.Equal("sandbox allow-forms allow-scripts allow-same-origin;block-all-mixed-content;upgrade-insecure-requests;",
+            _context.Response.Headers[Constants.ContentSecurityPolicyHeaderName]);
+    }
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+    [Fact]
+    public async Task Invoke_ContentSecurityPolicyHeaderName_HeaderIsNotPresent()
+    {
+        // arrange
+        var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
 
-            // assert
-            Assert.True(headerPresentConfig.UseXContentSecurityPolicy);
-            Assert.True(_context.Response.Headers.ContainsKey(Constants.XContentSecurityPolicyHeaderName));
-            Assert.Equal("block-all-mixed-content;upgrade-insecure-requests;",
-                _context.Response.Headers[Constants.XContentSecurityPolicyHeaderName]);
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-        }
+        // assert
+        Assert.False(headerNotPresentConfig.UseContentSecurityPolicy);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyHeaderName));
+    }
 
-        [Fact]
-        public async Task Invoke_XContentSecurityPolicyHeaderName_HeaderIsNotPresent()
-        {
-            // arrange
-            var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
+    [Fact]
+    public async Task Invoke_ContentSecurityPolicyReportOnly_HeaderIsPresent_WithMultipleCspSandboxTypes()
+    {
+        const string reportUri = "https://localhost:5001/report-uri";
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseContentSecurityPolicyReportOnly(reportUri).Build();
+        headerPresentConfig.SetCspSandBox(CspSandboxType.allowForms, CspSandboxType.allowScripts, CspSandboxType.allowSameOrigin);
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-            // assert
-            Assert.False(headerNotPresentConfig.UseXContentSecurityPolicy);
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.XContentSecurityPolicyHeaderName));
-        }
+        // assert
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyReportOnlyHeaderName));
+        Assert.Equal($"block-all-mixed-content;upgrade-insecure-requests;report-uri {reportUri};",
+            _context.Response.Headers[Constants.ContentSecurityPolicyReportOnlyHeaderName]);
+    }
 
-        [Fact]
-        public async Task Invoke_PermittedCrossDomainPoliciesHeaderName_HeaderIsPresent()
-        {
-            // arrange
-            var headerPresentConfig =
-                SecureHeadersMiddlewareBuilder.CreateBuilder().UsePermittedCrossDomainPolicies().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+    [Fact]
+    public async Task Invoke_ContentSecurityPolicyReportOnly_HeaderIsNotPresent()
+    {
+        // arrange
+        var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-            // assert
-            Assert.True(headerPresentConfig.UsePermittedCrossDomainPolicy);
-            Assert.True(_context.Response.Headers.ContainsKey(Constants.PermittedCrossDomainPoliciesHeaderName));
-            Assert.Equal("none;",
-                _context.Response.Headers[Constants.PermittedCrossDomainPoliciesHeaderName]);
-        }
+        // assert
+        Assert.False(headerNotPresentConfig.UseContentSecurityPolicyReportOnly);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.ContentSecurityPolicyReportOnlyHeaderName));
+    }
 
-        [Fact]
-        public async Task Invoke_PermittedCrossDomainPoliciesHeaderName_HeaderIsNotPresent()
-        {
-            // arrange
-            var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
+    [Fact]
+    public async Task Invoke_XContentSecurityPolicyHeaderName_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseContentSecurityPolicy(useXContentSecurityPolicy: true).Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-            // assert
-            Assert.False(headerNotPresentConfig.UsePermittedCrossDomainPolicy);
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.PermittedCrossDomainPoliciesHeaderName));
-        }
+        // assert
+        Assert.True(headerPresentConfig.UseXContentSecurityPolicy);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.XContentSecurityPolicyHeaderName));
+        Assert.Equal("block-all-mixed-content;upgrade-insecure-requests;",
+            _context.Response.Headers[Constants.XContentSecurityPolicyHeaderName]);
 
-        [Fact]
-        public async Task Invoke_ReferrerPolicyHeaderName_HeaderIsPresent()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseReferrerPolicy().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+    }
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+    [Fact]
+    public async Task Invoke_XContentSecurityPolicyHeaderName_HeaderIsNotPresent()
+    {
+        // arrange
+        var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
 
-            // assert
-            Assert.True(headerPresentConfig.UseReferrerPolicy);
-            Assert.True(_context.Response.Headers.ContainsKey(Constants.ReferrerPolicyHeaderName));
-            Assert.Equal("no-referrer", _context.Response.Headers[Constants.ReferrerPolicyHeaderName]);
-        }
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-        [Fact]
-        public async Task Invoke_ReferrerPolicyHeaderName_HeaderIsNotPresent()
-        {
-            // arrange
-            var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
+        // assert
+        Assert.False(headerNotPresentConfig.UseXContentSecurityPolicy);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.XContentSecurityPolicyHeaderName));
+    }
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+    [Fact]
+    public async Task Invoke_PermittedCrossDomainPoliciesHeaderName_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig =
+            SecureHeadersMiddlewareBuilder.CreateBuilder().UsePermittedCrossDomainPolicies().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
 
-            // assert
-            Assert.False(headerNotPresentConfig.UseReferrerPolicy);
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.ReferrerPolicyHeaderName));
-        }
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-        [Fact]
-        public async Task Invoke_ExpectCtHeaderName_HeaderIsPresent()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
-                .UseExpectCt("https://test.com/report").Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+        // assert
+        Assert.True(headerPresentConfig.UsePermittedCrossDomainPolicy);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.PermittedCrossDomainPoliciesHeaderName));
+        Assert.Equal("none;",
+            _context.Response.Headers[Constants.PermittedCrossDomainPoliciesHeaderName]);
+    }
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+    [Fact]
+    public async Task Invoke_PermittedCrossDomainPoliciesHeaderName_HeaderIsNotPresent()
+    {
+        // arrange
+        var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
 
-            // assert
-            Assert.True(headerPresentConfig.UseExpectCt);
-            Assert.True(_context.Response.Headers.ContainsKey(Constants.ExpectCtHeaderName));
-            Assert.Equal(headerPresentConfig.ExpectCt.BuildHeaderValue(),
-                _context.Response.Headers[Constants.ExpectCtHeaderName]);
-        }
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-        [Fact]
-        public async Task Invoke_ExpectCtHeaderName_HeaderIsPresent_ReportUri_Optional()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
-                .UseExpectCt(string.Empty).Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+        // assert
+        Assert.False(headerNotPresentConfig.UsePermittedCrossDomainPolicy);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.PermittedCrossDomainPoliciesHeaderName));
+    }
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+    [Fact]
+    public async Task Invoke_ReferrerPolicyHeaderName_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().UseReferrerPolicy().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
 
-            // assert
-            Assert.True(headerPresentConfig.UseExpectCt);
-            Assert.True(_context.Response.Headers.ContainsKey(Constants.ExpectCtHeaderName));
-            Assert.Equal(headerPresentConfig.ExpectCt.BuildHeaderValue(),
-                _context.Response.Headers[Constants.ExpectCtHeaderName]);
-        }
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-        [Fact]
-        public async Task Invoke_ExpectCtHeaderName_HeaderIsNotPresent()
-        {
-            // arrange
-            var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
+        // assert
+        Assert.True(headerPresentConfig.UseReferrerPolicy);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.ReferrerPolicyHeaderName));
+        Assert.Equal("no-referrer", _context.Response.Headers[Constants.ReferrerPolicyHeaderName]);
+    }
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+    [Fact]
+    public async Task Invoke_ReferrerPolicyHeaderName_HeaderIsNotPresent()
+    {
+        // arrange
+        var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
 
-            // assert
-            Assert.False(headerNotPresentConfig.UseExpectCt);
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.ExpectCtHeaderName));
-        }
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-        [Fact]
-        public async Task Invoke_XPoweredByHeader_RemoveHeader()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().RemovePoweredByHeader().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+        // assert
+        Assert.False(headerNotPresentConfig.UseReferrerPolicy);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.ReferrerPolicyHeaderName));
+    }
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+    [Fact]
+    public async Task Invoke_ExpectCtHeaderName_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
+            .UseExpectCt("https://test.com/report").Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
 
-            // assert
-            Assert.True(headerPresentConfig.RemoveXPoweredByHeader);
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.PoweredByHeaderName));
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.ServerHeaderName));
-        }
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-        [Fact]
-        public async Task Invoke_XPoweredByHeader_DoNotRemoveHeader()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+        // assert
+        Assert.True(headerPresentConfig.UseExpectCt);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.ExpectCtHeaderName));
+        Assert.Equal(headerPresentConfig.ExpectCt.BuildHeaderValue(),
+            _context.Response.Headers[Constants.ExpectCtHeaderName]);
+    }
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+    [Fact]
+    public async Task Invoke_ExpectCtHeaderName_HeaderIsPresent_ReportUri_Optional()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
+            .UseExpectCt(string.Empty).Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
 
-            // assert
-            Assert.False(headerPresentConfig.RemoveXPoweredByHeader);
-            // Am currently running the 2.1.300 Preview 1 build of the SDK
-            // and the server doesn't seem to add this header.
-            // Therefore this assert is commented out, as it will always fail
-            //Assert.True(_context.Response.Headers.ContainsKey(Constants.PoweredByHeaderName));
-        }
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-        [Fact]
-        public async Task Invoke_CacheControl_HeaderIsPresent()
-        {
-            // arrange
-            var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
-                .UseCacheControl().Build();
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+        // assert
+        Assert.True(headerPresentConfig.UseExpectCt);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.ExpectCtHeaderName));
+        Assert.Equal(headerPresentConfig.ExpectCt.BuildHeaderValue(),
+            _context.Response.Headers[Constants.ExpectCtHeaderName]);
+    }
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+    [Fact]
+    public async Task Invoke_ExpectCtHeaderName_HeaderIsNotPresent()
+    {
+        // arrange
+        var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
 
-            // assert
-            Assert.True(headerPresentConfig.UseCacheControl);
-            Assert.True(_context.Response.Headers.ContainsKey(Constants.CacheControlHeaderName));
-            Assert.Equal(headerPresentConfig.CacheControl.BuildHeaderValue(),
-                _context.Response.Headers[Constants.CacheControlHeaderName]);
-        }
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.False(headerNotPresentConfig.UseExpectCt);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.ExpectCtHeaderName));
+    }
+
+    [Fact]
+    public async Task Invoke_XPoweredByHeader_RemoveHeader()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().RemovePoweredByHeader().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.True(headerPresentConfig.RemoveXPoweredByHeader);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.PoweredByHeaderName));
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.ServerHeaderName));
+    }
+
+    [Fact]
+    public async Task Invoke_XPoweredByHeader_DoNotRemoveHeader()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.False(headerPresentConfig.RemoveXPoweredByHeader);
+        // Am currently running the 2.1.300 Preview 1 build of the SDK
+        // and the server doesn't seem to add this header.
+        // Therefore this assert is commented out, as it will always fail
+        //Assert.True(_context.Response.Headers.ContainsKey(Constants.PoweredByHeaderName));
+    }
+
+    [Fact]
+    public async Task Invoke_CacheControl_HeaderIsPresent()
+    {
+        // arrange
+        var headerPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
+            .UseCacheControl().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.True(headerPresentConfig.UseCacheControl);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.CacheControlHeaderName));
+        Assert.Equal(headerPresentConfig.CacheControl.BuildHeaderValue(),
+            _context.Response.Headers[Constants.CacheControlHeaderName]);
+    }
         
-        [Fact]
-        public async Task Invoke_CacheControl_HeaderIsNotPresent()
-        {
-            // arrange
-            var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder();
-            headerNotPresentConfig.UseCacheControl = false;
-            headerNotPresentConfig.Build();
+    [Fact]
+    public async Task Invoke_CacheControl_HeaderIsNotPresent()
+    {
+        // arrange
+        var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder();
+        headerNotPresentConfig.UseCacheControl = false;
+        headerNotPresentConfig.Build();
             
-            var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
 
-            // act
-            await secureHeadersMiddleware.Invoke(_context);
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
 
-            // assert
-            Assert.False(headerNotPresentConfig.UseCacheControl);
-            Assert.False(_context.Response.Headers.ContainsKey(Constants.CacheControlHeaderName));
-        }
+        // assert
+        Assert.False(headerNotPresentConfig.UseCacheControl);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.CacheControlHeaderName));
     }
 }


### PR DESCRIPTION
## Rationale for PR

This PR fixes [issue #61](https://github.com/GaProgMan/OwaspHeaders.Core/issues/61). This is achieved by simultaneously reducing the complexity of the `BuildValuesForDirective` method, and by increasing the test coverage for the Middleware.

Also included are:

- a number of small changes to the file-level namespace layouts (using the new single-line style of namespace declarations)
- A fix for the name of the Middleware Invoke method (means it will actually work with .NET 6+)
- Excluded all test code classes from code coverage
- Upped version number to match changes