### PR TITLE
Re-enabled code-checking action

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,30 +7,30 @@ on:
 
 jobs:
 
-  # check-code-formatting:
-  #   runs-on: ubuntu-latest
-  #   name: Check code formatting against editorconfig
+  check-code-formatting:
+    runs-on: ubuntu-latest
+    name: Check code formatting against editorconfig
 
-  #   steps:
-  #   - name: Checkout code
-  #     uses: actions/checkout@v3
-  #     with:
-  #       fetch-depth: 1
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
 
-  #   - name: Setup .NET
-  #     uses: actions/setup-dotnet@v3
-  #     with:
-  #       dotnet-version: 6.0.x
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
 
-  #   - name: Install dotnet-format tool
-  #     run: dotnet tool install -g dotnet-format
+    - name: Install dotnet-format tool
+      run: dotnet tool install -g dotnet-format
     
-  #   - name: Check Code Format
-  #     run: dotnet-format --check
+    - name: Check Code Format
+      run: dotnet-format --check
 
   build:
 
-    # needs: [check-code-formatting]
+    needs: [check-code-formatting]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Rationale for PR

This PR re-enables code-checking action on all PRs. The build stage is now dependent on the code-checking stage completing for any future PRs.

This will help to the code base in the main branch to adhere to the .editorconfig rules.