### PR TITLE
Version bump

### DIFF
--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An ASP.NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
-    <VersionPrefix>4.6.1</VersionPrefix>
+    <VersionPrefix>4.6.2</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>


### PR DESCRIPTION
## Rationale for PR

Due to recent (repo infrastructure) changes, the version number of the package has had to be bumped. This is because NuGet will not allow a package to be uploaded with the same version number.