### PR TITLE
Bugfix/expect ct deprecated

### DIFF
--- a/src/Extensions/SecureHeadersMiddlewareBuilder.cs
+++ b/src/Extensions/SecureHeadersMiddlewareBuilder.cs
@@ -273,7 +273,7 @@ namespace OwaspHeaders.Core.Extensions
 
         /// <summary>
         /// Governs whether the site can opt-into reporting or enforcement of certificate
-        /// transparency requirements, which prevents the use of misissued certificates
+        /// transparency requirements, which prevents the use of mis-issued certificates
         /// for that site from going unnoticed
         /// </summary>
         /// <param name="reportUri">

--- a/src/Extensions/SecureHeadersMiddlewareExtensions.cs
+++ b/src/Extensions/SecureHeadersMiddlewareExtensions.cs
@@ -31,14 +31,13 @@ namespace OwaspHeaders.Core.Extensions
                 .UsePermittedCrossDomainPolicies()
                 .UseReferrerPolicy()
                 .UseCacheControl()
-                .UseExpectCt(string.Empty, enforce: true)
                 .RemovePoweredByHeader()
                 .UseXssProtection()
                 .Build();
         }
 
         /// <summary>
-        /// Extention method to include the <see cref="SecureHeadersMiddleware" /> in
+        /// Extension method to include the <see cref="SecureHeadersMiddleware" /> in
         /// an instance of an <see cref="IApplicationBuilder" />.
         /// This works in the same way was the MVC, Static files, etc. middleware
         /// </summary>

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An ASP.NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>6.0.0</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>


### PR DESCRIPTION
Expect-CT has been disabled by default, this is related to the following, which is taken directly from the OWASP Secure Headers Project (as of May 11th, 2023):

> Deprecated.

> ⚠️ Warning: This header will likely become obsolete in June 2021. Since May 2018 new certificates are expected to support SCTs by default. Certificates before March 2018 were allowed to have a lifetime of 39 months, those will all be expired in June 2021.

source: https://owasp.org/www-project-secure-headers/#expect-ct