### PR TITLE
Feature/add dotnet format to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Please note: this middleware **DOES NOT SUPPORT BLAZOR OR WEBASSEMBLY APPLICATIO
 
 - .NET vLatest
 - an IDE (VS Code, Rider, or Visual Studio)
+- [dotnet-format](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-format) global tool.
 
 That's it.
 
@@ -20,6 +21,8 @@ That's it.
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
 Pull requests are welcome, but please take a moment to read the Code of Conduct before submitting them or commenting on any work in this repo.
+
+Also please make sure to run `dotnet format OwaspHeaders.Core.sln` in the root of the repo _before_ submitting a PR. This repo uses an [editorconfig](.editorconfig) file to enforce certain formatting rules on this repo. Any PRs which don't adhere to these formatting rules will fail a PR action (for checking the code against the rules). So to save time, please run `dotnet format OwaspHeaders.Core.sln` ahead of submitting your PR.
 
 ## Getting Started
 
@@ -42,7 +45,7 @@ This will add a number of default HTTP headers to all responses from your server
 
 The following is an example of the response headers from version 6.0.2 (taken on May 15th, 2023)
 
-``` plaintext
+```plaintext
 cache-control: max-age=31536000, private
 strict-transport-security: max-age=63072000;includeSubDomains
 x-frame-options: DENY
@@ -67,29 +70,11 @@ This Middleware uses the builder pattern to set up the header information, which
 
 In your `Startup` class (or `Program.cs` for .NET 6 onwards):
 
-```csharp
-app.UseSecureHeadersMiddleware(SecureHeadersMiddlewareExtensions.BuildDefaultConfiguration());
-```
+https://github.com/GaProgMan/OwaspHeaders.Core/blob/433cbb764956e86b80b598c5d0760bdfdef28161/example/Program.cs#L26
 
 This will use the default configuration for the OwaspHeaders.Core middleware. The method (found in `/src/Extensions/SecureHeadersMiddlewareExtensions.cs`) looks like this:
 
-``` csharp
-public static SecureHeadersMiddlewareConfiguration BuildDefaultConfiguration()
-{
-    return SecureHeadersMiddlewareBuilder
-        .CreateBuilder()
-        .UseHsts()
-        .UseXFrameOptions()
-        .UseContentTypeOptions()
-        .UseContentDefaultSecurityPolicy()
-        .UsePermittedCrossDomainPolicies()
-        .UseReferrerPolicy()
-        .UseCacheControl()
-        .RemovePoweredByHeader()
-        .UseXssProtection()
-        .Build();
-}
-```
+https://github.com/GaProgMan/OwaspHeaders.Core/blob/433cbb764956e86b80b598c5d0760bdfdef28161/src/Extensions/SecureHeadersMiddlewareExtensions.cs#L23-L38
 
 ### Custom Configuration
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ This changelog represents all of the major (i.e. breaking) changes made to the O
 
 | Major Version Number | Changes |
 |---|---|
+| 7 | Added Cross-Origin-Resource-Policy header to list of defaults |
+| 6 | Removes Expect-CT Header from the list of default headers |
 | 5 | XSS Protection is now hard-coded to return "0" if enabled |
 | 4 | Uses builder pattern to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> uses .NET Standard 2.0 <br /> Removed XSS Protection header from defaults |
 | 3 | Uses builder pattern to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Standard 2.0 |
@@ -14,7 +16,7 @@ This changelog represents all of the major (i.e. breaking) changes made to the O
 
 ### Version 7
 
-This version adds the Cross-Origin-Resource-Policy header with the OWASP recommended value "same-origin" to the list of default headers in the `BuildDefaultConfiguration()` extension method. This was requested via [issue #76](https://github.com/GaProgMan/OwaspHeaders.Core/issues/76). 
+This version adds the Cross-Origin-Resource-Policy header with the OWASP recommended value "same-origin" to the list of default headers in the `BuildDefaultConfiguration()` extension method. This was requested via [issue #76](https://github.com/GaProgMan/OwaspHeaders.Core/issues/76).
 
 ### Version 6
 

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An ASP.NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>7.0.1</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/OwaspHeadersCore.nuspec
+++ b/src/OwaspHeadersCore.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>OwaspHeaders.Core</id>
-    <version>7.0.0</version>
+    <version>7.0.1</version>
     <authors>GaProgMan</authors>
     <owners>GaProgMan</owners>
     <readme>docs\README-NuGet.md</readme>


### PR DESCRIPTION
### Rationale for PR

I noticed that the dotnet-format stuff was not listed in the readme, this can lead to all sorts of issues when a new contributor comes along and their PR fails the CI pipeline for not adhering to the coding standards.

Also, the changelog table needed to be updated.

### Changes

- Added section to readme about dotnet-format
- Added section to readme asking contributors to run `dotnet format OwaspHeaders.Core.sln`
- Updated table in changelog to include versions 6 + 7
- Patch version bump for release