### PR TITLE
Removed references to Moq

### DIFF
--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
The purpose of this repo is to promote security - both for our users and the developers who write the code that they rely on. As such, all references to Moq have been removed.

See [issue 1372 on the Moq repo](https://github.com/moq/moq/issues/1372) for background information.