### PR TITLE
Feature/add net 8

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Jamie Taylor
+Copyright (c) 2024 Jamie Taylor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/OwaspHeaders.Core.Tests/HttpContextExtensionsTests/TryAdd.cs
+++ b/OwaspHeaders.Core.Tests/HttpContextExtensionsTests/TryAdd.cs
@@ -30,7 +30,16 @@ namespace OwaspHeaders.Core.Tests.HttpContextExtensionsTests
             var headerName = Guid.NewGuid().ToString();
             var headerBody = Guid.NewGuid().ToString();
 
+            // ASP0019 states that:
+            // "IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key."
+            // However, we've already done a check to see whether the
+            // Response.Headers object cannot contain this header (as we're in
+            // the setup stage of a test).
+            // So we'll disable the warning here then immediately restore it
+            // after we've done what we need to.
+            #pragma warning disable ASP0019
             _context.Response.Headers.Add(headerName, headerBody);
+            #pragma warning restore ASP0019
 
             // Act
             var response = _context.TryAddHeader(headerName, headerBody);

--- a/OwaspHeaders.Core.Tests/HttpContextExtensionsTests/TryAdd.cs
+++ b/OwaspHeaders.Core.Tests/HttpContextExtensionsTests/TryAdd.cs
@@ -37,9 +37,9 @@ namespace OwaspHeaders.Core.Tests.HttpContextExtensionsTests
             // the setup stage of a test).
             // So we'll disable the warning here then immediately restore it
             // after we've done what we need to.
-            #pragma warning disable ASP0019
+#pragma warning disable ASP0019
             _context.Response.Headers.Add(headerName, headerBody);
-            #pragma warning restore ASP0019
+#pragma warning restore ASP0019
 
             // Act
             var response = _context.TryAddHeader(headerName, headerBody);

--- a/OwaspHeaders.Core.Tests/HttpContextExtensionsTests/TryRemove.cs
+++ b/OwaspHeaders.Core.Tests/HttpContextExtensionsTests/TryRemove.cs
@@ -15,7 +15,17 @@ namespace OwaspHeaders.Core.Tests.HttpContextExtensionsTests
             // Arrange
             var headerName = Guid.NewGuid().ToString();
             var headerBody = Guid.NewGuid().ToString();
+            
+            // ASP0019 states that:
+            // "IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key."
+            // However, we've already done a check to see whether the
+            // Response.Headers object cannot contain this header (as we're in
+            // the setup stage of a test).
+            // So we'll disable the warning here then immediately restore it
+            // after we've done what we need to.
+            #pragma warning disable ASP0019
             _context.Response.Headers.Add(headerName, headerBody);
+            #pragma warning restore ASP0019
 
             // Act
             var response = _context.TryRemoveHeader(headerName);

--- a/OwaspHeaders.Core.Tests/HttpContextExtensionsTests/TryRemove.cs
+++ b/OwaspHeaders.Core.Tests/HttpContextExtensionsTests/TryRemove.cs
@@ -15,7 +15,7 @@ namespace OwaspHeaders.Core.Tests.HttpContextExtensionsTests
             // Arrange
             var headerName = Guid.NewGuid().ToString();
             var headerBody = Guid.NewGuid().ToString();
-            
+
             // ASP0019 states that:
             // "IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key."
             // However, we've already done a check to see whether the
@@ -23,9 +23,9 @@ namespace OwaspHeaders.Core.Tests.HttpContextExtensionsTests
             // the setup stage of a test).
             // So we'll disable the warning here then immediately restore it
             // after we've done what we need to.
-            #pragma warning disable ASP0019
+#pragma warning disable ASP0019
             _context.Response.Headers.Add(headerName, headerBody);
-            #pragma warning restore ASP0019
+#pragma warning restore ASP0019
 
             // Act
             var response = _context.TryRemoveHeader(headerName);

--- a/OwaspHeaders.Core.Tests/OwaspHeaders.Core.Tests.csproj
+++ b/OwaspHeaders.Core.Tests/OwaspHeaders.Core.Tests.csproj
@@ -4,7 +4,7 @@
     <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core.Tests</AssemblyName>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/README.md
+++ b/README.md
@@ -13,13 +13,11 @@ Please note: this middleware **DOES NOT SUPPORT BLAZOR OR WEBASSEMBLY APPLICATIO
 - .NET SDKs vLatest
   - 6.0
   - 7.0
-  - 8.0&ast;
+  - 8.0
 - an IDE (VS Code, Rider, or Visual Studio)
 - [dotnet-format](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-format) global tool.
 
 That's it.
-
-&ast; = at the time of pushing version 8 of the repo (Dec 2nd, 2023), the .NET 8 SDK binaries are not available for some Linux distributions (such as Fedora). If v8.0 of .NET is not available for your chosen distro, remove the `net8.0` TFM from all csproj files in order to build and run the code.
 
 ## Pull Requests
 

--- a/src/Extensions/HttpContextExtensions.cs
+++ b/src/Extensions/HttpContextExtensions.cs
@@ -18,7 +18,16 @@ namespace OwaspHeaders.Core.Extensions
             }
             try
             {
-                httpContext.Response.Headers.Add(headerName, headerValue);
+                // ASP0019 states that:
+                // "IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key."
+                // However, we've already done a check to see whether the
+                // Response.Headers object
+                // already contains a header with this name (in the above if statement).
+                // So we'll disable the warning here then immediately restore it
+                // after we've done what we need to.
+                #pragma warning disable ASP0019
+                httpContext.Response.Headers.Append(headerName, headerValue);
+                #pragma warning restore ASP0019
                 return true;
             }
             catch (ArgumentException)

--- a/src/Extensions/HttpContextExtensions.cs
+++ b/src/Extensions/HttpContextExtensions.cs
@@ -25,9 +25,9 @@ namespace OwaspHeaders.Core.Extensions
                 // already contains a header with this name (in the above if statement).
                 // So we'll disable the warning here then immediately restore it
                 // after we've done what we need to.
-                #pragma warning disable ASP0019
+#pragma warning disable ASP0019
                 httpContext.Response.Headers.Append(headerName, headerValue);
-                #pragma warning restore ASP0019
+#pragma warning restore ASP0019
                 return true;
             }
             catch (ArgumentException)

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -4,7 +4,7 @@
     <VersionPrefix>8.0.0</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <PackageId>OwaspHeaders.Core</PackageId>
     <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>An ASP.NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
-    <VersionPrefix>8.0.0</VersionPrefix>
+    <VersionPrefix>8.1.0</VersionPrefix>
     <Authors>Jamie Taylor</Authors>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>

--- a/src/OwaspHeadersCore.nuspec
+++ b/src/OwaspHeadersCore.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>OwaspHeaders.Core</id>
-    <version>7.5.1</version>
+    <version>8.1.0</version>
     <authors>GaProgMan</authors>
     <owners>GaProgMan</owners>
     <readme>docs\README-NuGet.md</readme>


### PR DESCRIPTION
### Rationale For This PR

This library didn't explicitly support .NET 8 out of the box. .NET was released in November of 2023, so it was time to support it.

This PR adds support for .NET 8 to both OwaspHeaders.Core and the Tests library. It also contains a version bump to 8.1.0 - the rationale for the version bump as a minor version change is that this doesn't represent a major change in functionality (unless consumers are using .NET8, that is).

### Warnings

The following warnings have been explicitly disabled in this PR:

- ASP0019

ASP0019 is related to calling `Repsonse.Headers.Add(string, string)` on the HttpContext object and states:

>IDictionary.Add will throw an ArgumentException when attempting to add a duplicate key

This warning can be safely ignored because injecting a header with the same name in the three places where this warning occurs is _very_ difficult to do. In fact, the two places where it happens in the OwaspHeaders.Test project would require code changes to make it happen, and if that happens then the tests will fail anyway.

It's not impossible for this to happen in the the actually library code (i.e. at `public static bool ResponseContainsHeader(this HttpContext httpContext, string header)` in Extensions/HttpContextExtensions.cs), but making it happen would require some precise timing and thread unsafe code. It's possible, but would be hard to do.