### PR TITLE
Added warnings as errors to csproj files

### DIFF
--- a/OwaspHeaders.Core.Example/OwaspHeaders.Core.Example.csproj
+++ b/OwaspHeaders.Core.Example/OwaspHeaders.Core.Example.csproj
@@ -5,6 +5,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/OwaspHeaders.Core.Tests/OwaspHeaders.Core.Tests.csproj
+++ b/OwaspHeaders.Core.Tests/OwaspHeaders.Core.Tests.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>OwaspHeaders.Core.Tests</AssemblyName>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -4,10 +4,11 @@
 
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <AssemblyName>OwaspHeaders.Core</AssemblyName>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!-- NuGet metadata -->
     <PackageId>OwaspHeaders.Core</PackageId>
-    <Version>9.0.0</Version>
+    <Version>9.0.1</Version>
     <Authors>Jamie Taylor</Authors>
     <Company>RJJ Software Ltd</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
### Rationale for PR

This PR adds the `TreatWarningsAsErrors` flag to all csproj files. This will greatly increase the chances of catching compiler warnings when building (either locally or in CI).

Also included is a patch-level version number bump.
