### PR TITLE
Feature/ignore provided urls

### DIFF
--- a/example/OwaspHeaders.Core.Example/Controllers/HomeController.cs
+++ b/example/OwaspHeaders.Core.Example/Controllers/HomeController.cs
@@ -13,7 +13,7 @@ public class HomeController(ILogger<HomeController> logger) : ControllerBase
     {
         return GetHeaders;
     }
-    
+
     [HttpGet("skipthis", Name = "SkipThis")]
     public IEnumerable<string> SkipThis()
     {

--- a/example/OwaspHeaders.Core.Example/Controllers/HomeController.cs
+++ b/example/OwaspHeaders.Core.Example/Controllers/HomeController.cs
@@ -8,9 +8,17 @@ public class HomeController(ILogger<HomeController> logger) : ControllerBase
 {
     private readonly ILogger<HomeController> _logger = logger;
 
-[HttpGet(Name = "/")]
-public IEnumerable<string> Get()
-{
-    return HttpContext.Response.Headers.Select(h => h.ToString()).ToArray();
-}
+    [HttpGet(Name = "/")]
+    public IEnumerable<string> Get()
+    {
+        return GetHeaders;
+    }
+    
+    [HttpGet("skipthis", Name = "SkipThis")]
+    public IEnumerable<string> SkipThis()
+    {
+        return GetHeaders;
+    }
+
+    private IEnumerable<string> GetHeaders => HttpContext.Response.Headers.Select(h => h.ToString()).ToArray();
 }

--- a/example/OwaspHeaders.Core.Example/Controllers/HomeController.cs
+++ b/example/OwaspHeaders.Core.Example/Controllers/HomeController.cs
@@ -8,17 +8,17 @@ public class HomeController(ILogger<HomeController> logger) : ControllerBase
 {
     private readonly ILogger<HomeController> _logger = logger;
 
-    [HttpGet(Name = "/")]
-    public IEnumerable<string> Get()
-    {
-        return GetHeaders;
-    }
+[HttpGet(Name = "/")]
+public IEnumerable<string> Get()
+{
+    return GetHeaders;
+}
 
-    [HttpGet("skipthis", Name = "SkipThis")]
-    public IEnumerable<string> SkipThis()
-    {
-        return GetHeaders;
-    }
+[HttpGet("skipthis", Name = "SkipThis")]
+public IEnumerable<string> SkipThis()
+{
+    return GetHeaders;
+}
 
-    private IEnumerable<string> GetHeaders => HttpContext.Response.Headers.Select(h => h.ToString()).ToArray();
+private IEnumerable<string> GetHeaders => HttpContext.Response.Headers.Select(h => h.ToString()).ToArray();
 }

--- a/example/OwaspHeaders.Core.Example/Program.cs
+++ b/example/OwaspHeaders.Core.Example/Program.cs
@@ -20,7 +20,8 @@ app.UseHttpsRedirection();
 
 app.UseAuthorization();
 
-app.UseSecureHeadersMiddleware();
+var listOfUrlsToIgnore = new List<string> { "/skipthis" };
+app.UseSecureHeadersMiddleware(urlIgnoreList: listOfUrlsToIgnore);
 
 app.MapControllers();
 

--- a/src/Extensions/SecureHeadersMiddlewareBuilder.cs
+++ b/src/Extensions/SecureHeadersMiddlewareBuilder.cs
@@ -319,6 +319,25 @@ namespace OwaspHeaders.Core.Extensions
         }
 
         /// <summary>
+        /// Used to set a list of URLs that the we want the middleware to NOT operate on
+        /// </summary>
+        /// <param name="config"></param>
+        /// <param name="urlsToIgnore">
+        /// A list of URLs that we the middleware to not operate on
+        /// </param>
+        /// <returns></returns>
+        public static SecureHeadersMiddlewareConfiguration SetUrlsToIgnore(
+            this SecureHeadersMiddlewareConfiguration config,
+            List<string> urlsToIgnore = null)
+        {
+            if (urlsToIgnore != null)
+            {
+                config.UrlsToIgnore = urlsToIgnore;
+            }
+            return config;
+        }
+
+        /// <summary>
         /// Return the completed <see cref="SecureHeadersMiddlewareConfiguration"/> ready for consumption by the
         /// <see cref="SecureHeadersMiddleware"/> class
         /// </summary>

--- a/src/Extensions/SecureHeadersMiddlewareExtensions.cs
+++ b/src/Extensions/SecureHeadersMiddlewareExtensions.cs
@@ -19,7 +19,8 @@ namespace OwaspHeaders.Core.Extensions
         /// url for the current best practises:
         /// https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#tab=Best_Practices
         /// </remarks>
-        public static SecureHeadersMiddlewareConfiguration BuildDefaultConfiguration()
+        public static SecureHeadersMiddlewareConfiguration BuildDefaultConfiguration(
+            List<string> urlIgnoreList = null)
         {
             return SecureHeadersMiddlewareBuilder
                 .CreateBuilder()
@@ -32,6 +33,7 @@ namespace OwaspHeaders.Core.Extensions
                 .UseCacheControl()
                 .UseXssProtection()
                 .UseCrossOriginResourcePolicy()
+                .SetUrlsToIgnore(urlIgnoreList)
                 .Build();
         }
 
@@ -47,6 +49,11 @@ namespace OwaspHeaders.Core.Extensions
         /// [OPTIONAL] An instance of the <see cref="SecureHeadersMiddlewareConfiguration" />
         /// containing all the config for each request
         /// </param>
+        /// <param name="urlIgnoreList">
+        /// A list of URLs to ignore when processes requests. For example, to disable the entire
+        /// middleware when the user accesses "/path-to-ignore", add this to the list and the
+        /// middleware will be disabled for that URL.
+        /// </param>
         /// <returns>
         /// The <see cref="IApplicationBuilder"/> with the <see cref="SecureHeadersMiddleware" /> added
         /// </returns>
@@ -55,11 +62,11 @@ namespace OwaspHeaders.Core.Extensions
         /// then the default value from <see cref="BuildDefaultConfiguration"/> will be provided.
         /// </remarks>
         public static IApplicationBuilder UseSecureHeadersMiddleware(this IApplicationBuilder builder,
-            SecureHeadersMiddlewareConfiguration config = null)
+            SecureHeadersMiddlewareConfiguration config = null, List<string> urlIgnoreList = null)
         {
             ObjectGuardClauses.ObjectCannotBeNull(builder, nameof(builder),
                 "cannot be null when setting up OWASP Secure Headers in OwaspHeaders.Core");
-            return builder.UseMiddleware<SecureHeadersMiddleware>(config ?? BuildDefaultConfiguration());
+            return builder.UseMiddleware<SecureHeadersMiddleware>(config ?? BuildDefaultConfiguration(urlIgnoreList));
         }
     }
 }

--- a/src/Models/CrossOriginResourcePolicy.cs
+++ b/src/Models/CrossOriginResourcePolicy.cs
@@ -17,51 +17,51 @@
         /// Only requests from the same Origin (i.e. scheme + host + port) can read the resource.
         /// </summary>
         public const string SameOriginValue = "same-origin";
-    /// <summary>
-    /// Only requests from the same Site can read the resource.
-    /// </summary>
-    public const string SameSiteValue = "same-site";
-    /// <summary>
-    /// Requests from any Origin (both same-site and cross-site) can read the resource. 
-    /// Browsers are using this policy when an CORP header is not specified.
-    /// </summary>
-    public const string CrossOriginValue = "cross-origin";
-
-    public enum CrossOriginResourceOptions
-    {
         /// <summary>
-        /// <see cref="SameOriginValue"/>
+        /// Only requests from the same Site can read the resource.
         /// </summary>
-        SameOrigin,
+        public const string SameSiteValue = "same-site";
         /// <summary>
-        /// <see cref="SameSiteValue"/>
+        /// Requests from any Origin (both same-site and cross-site) can read the resource. 
+        /// Browsers are using this policy when an CORP header is not specified.
         /// </summary>
-        SameSite,
-        /// <summary>
-        /// <see cref="CrossOriginValue"/>
-        /// </summary>
-        CrossOrigin
-    };
+        public const string CrossOriginValue = "cross-origin";
 
-    private CrossOriginResourceOptions OptionValue { get; } = value;
-
-    /// <summary>
-    /// Builds the HTTP header value
-    /// </summary>
-    /// <returns>A string representing the HTTP header value</returns>
-    public string BuildHeaderValue()
-    {
-        switch (OptionValue)
+        public enum CrossOriginResourceOptions
         {
-            case CrossOriginResourceOptions.CrossOrigin:
-                return CrossOriginValue;
-            case CrossOriginResourceOptions.SameSite:
-                return SameSiteValue;
-            case CrossOriginResourceOptions.SameOrigin:
-            default:
-                return SameOriginValue;
-        }
-    }
+            /// <summary>
+            /// <see cref="SameOriginValue"/>
+            /// </summary>
+            SameOrigin,
+            /// <summary>
+            /// <see cref="SameSiteValue"/>
+            /// </summary>
+            SameSite,
+            /// <summary>
+            /// <see cref="CrossOriginValue"/>
+            /// </summary>
+            CrossOrigin
+        };
 
-}
+        private CrossOriginResourceOptions OptionValue { get; } = value;
+
+        /// <summary>
+        /// Builds the HTTP header value
+        /// </summary>
+        /// <returns>A string representing the HTTP header value</returns>
+        public string BuildHeaderValue()
+        {
+            switch (OptionValue)
+            {
+                case CrossOriginResourceOptions.CrossOrigin:
+                    return CrossOriginValue;
+                case CrossOriginResourceOptions.SameSite:
+                    return SameSiteValue;
+                case CrossOriginResourceOptions.SameOrigin:
+                default:
+                    return SameOriginValue;
+            }
+        }
+
+    }
 }

--- a/src/Models/CrossOriginResourcePolicy.cs
+++ b/src/Models/CrossOriginResourcePolicy.cs
@@ -17,51 +17,51 @@
         /// Only requests from the same Origin (i.e. scheme + host + port) can read the resource.
         /// </summary>
         public const string SameOriginValue = "same-origin";
-        /// <summary>
-        /// Only requests from the same Site can read the resource.
-        /// </summary>
-        public const string SameSiteValue = "same-site";
-        /// <summary>
-        /// Requests from any Origin (both same-site and cross-site) can read the resource. 
-        /// Browsers are using this policy when an CORP header is not specified.
-        /// </summary>
-        public const string CrossOriginValue = "cross-origin";
+    /// <summary>
+    /// Only requests from the same Site can read the resource.
+    /// </summary>
+    public const string SameSiteValue = "same-site";
+    /// <summary>
+    /// Requests from any Origin (both same-site and cross-site) can read the resource. 
+    /// Browsers are using this policy when an CORP header is not specified.
+    /// </summary>
+    public const string CrossOriginValue = "cross-origin";
 
-        public enum CrossOriginResourceOptions
+    public enum CrossOriginResourceOptions
+    {
+        /// <summary>
+        /// <see cref="SameOriginValue"/>
+        /// </summary>
+        SameOrigin,
+        /// <summary>
+        /// <see cref="SameSiteValue"/>
+        /// </summary>
+        SameSite,
+        /// <summary>
+        /// <see cref="CrossOriginValue"/>
+        /// </summary>
+        CrossOrigin
+    };
+
+    private CrossOriginResourceOptions OptionValue { get; } = value;
+
+    /// <summary>
+    /// Builds the HTTP header value
+    /// </summary>
+    /// <returns>A string representing the HTTP header value</returns>
+    public string BuildHeaderValue()
+    {
+        switch (OptionValue)
         {
-            /// <summary>
-            /// <see cref="SameOriginValue"/>
-            /// </summary>
-            SameOrigin,
-            /// <summary>
-            /// <see cref="SameSiteValue"/>
-            /// </summary>
-            SameSite,
-            /// <summary>
-            /// <see cref="CrossOriginValue"/>
-            /// </summary>
-            CrossOrigin
-        };
-
-        private CrossOriginResourceOptions OptionValue { get; } = value;
-
-        /// <summary>
-        /// Builds the HTTP header value
-        /// </summary>
-        /// <returns>A string representing the HTTP header value</returns>
-        public string BuildHeaderValue()
-        {
-            switch (OptionValue)
-            {
-                case CrossOriginResourceOptions.CrossOrigin:
-                    return CrossOriginValue;
-                case CrossOriginResourceOptions.SameSite:
-                    return SameSiteValue;
-                case CrossOriginResourceOptions.SameOrigin:
-                default:
-                    return SameOriginValue;
-            }
+            case CrossOriginResourceOptions.CrossOrigin:
+                return CrossOriginValue;
+            case CrossOriginResourceOptions.SameSite:
+                return SameSiteValue;
+            case CrossOriginResourceOptions.SameOrigin:
+            default:
+                return SameOriginValue;
         }
-
     }
+
+}
 }

--- a/src/Models/SecureHeadersMiddlewareConfiguration.cs
+++ b/src/Models/SecureHeadersMiddlewareConfiguration.cs
@@ -113,5 +113,11 @@
         public ExpectCt ExpectCt { get; set; }
 
         public CrossOriginResourcePolicy CrossOriginResourcePolicy { get; set; }
+
+        /// <summary>
+        /// A list of URLs that, when requested, should be ignored completely by
+        /// the middleware
+        /// </summary>
+        public List<string> UrlsToIgnore { get; set; } = [];
     }
 }

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>OwaspHeaders.Core</PackageId>
-    <Version>9.3.0</Version>
+    <Version>9.4.0</Version>
     <Authors>Jamie Taylor</Authors>
     <Company>RJJ Software Ltd</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/SecureHeadersMiddleware.cs
+++ b/src/SecureHeadersMiddleware.cs
@@ -11,115 +11,115 @@ namespace OwaspHeaders.Core
     {
         private string _calculatedContentSecurityPolicy;
 
-        /// <summary>
-        /// The main task of the middleware. This will be invoked whenever
-        /// the middleware fires
-        /// </summary>
-        /// <param name="httpContext">The <see cref="HttpContext" /> for the current request or response</param>
-        /// <returns></returns>
-        public async Task InvokeAsync(HttpContext httpContext)
+    /// <summary>
+    /// The main task of the middleware. This will be invoked whenever
+    /// the middleware fires
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext" /> for the current request or response</param>
+    /// <returns></returns>
+    public async Task InvokeAsync(HttpContext httpContext)
+    {
+        if (config == null)
         {
-            if (config == null)
-            {
-                throw new ArgumentException($"Expected an instance of the {nameof(SecureHeadersMiddlewareConfiguration)} object.");
-            }
-
-            if (!RequestShouldBeIgnored(httpContext.Request.Path))
-            {
-                if (config.UseHsts)
-                {
-                    httpContext.TryAddHeader(Constants.StrictTransportSecurityHeaderName,
-                        config.HstsConfiguration.BuildHeaderValue());
-                }
-
-                if (config.UseXFrameOptions)
-                {
-                    httpContext.TryAddHeader(Constants.XFrameOptionsHeaderName,
-                        config.XFrameOptionsConfiguration.BuildHeaderValue());
-                }
-
-                if (config.UseXssProtection)
-                {
-                    httpContext.TryAddHeader(Constants.XssProtectionHeaderName,
-                        config.XssConfiguration.BuildHeaderValue());
-                }
-
-                if (config.UseXContentTypeOptions)
-                {
-                    httpContext.TryAddHeader(Constants.XContentTypeOptionsHeaderName, "nosniff");
-                }
-
-                if (config.UseContentSecurityPolicyReportOnly)
-                {
-                    if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
-                    {
-                        _calculatedContentSecurityPolicy =
-                            config.ContentSecurityPolicyReportOnlyConfiguration.BuildHeaderValue();
-                    }
-
-                    httpContext.TryAddHeader(Constants.ContentSecurityPolicyReportOnlyHeaderName,
-                        _calculatedContentSecurityPolicy);
-                }
-                else if (config.UseContentSecurityPolicy)
-                {
-                    if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
-                    {
-                        _calculatedContentSecurityPolicy = config.ContentSecurityPolicyConfiguration.BuildHeaderValue();
-                    }
-
-                    httpContext.TryAddHeader(Constants.ContentSecurityPolicyHeaderName,
-                        _calculatedContentSecurityPolicy);
-                }
-
-                if (config.UseXContentSecurityPolicy)
-                {
-                    httpContext.TryAddHeader(Constants.XContentSecurityPolicyHeaderName,
-                        config.ContentSecurityPolicyConfiguration.BuildHeaderValue());
-                }
-
-                if (config.UsePermittedCrossDomainPolicy)
-                {
-                    httpContext.TryAddHeader(Constants.PermittedCrossDomainPoliciesHeaderName,
-                        config.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
-                }
-
-                if (config.UseReferrerPolicy)
-                {
-                    httpContext.TryAddHeader(Constants.ReferrerPolicyHeaderName,
-                        config.ReferrerPolicy.BuildHeaderValue());
-                }
-
-                if (config.UseExpectCt)
-                {
-                    httpContext.TryAddHeader(Constants.ExpectCtHeaderName,
-                        config.ExpectCt.BuildHeaderValue());
-                }
-
-                if (config.UseCacheControl)
-                {
-                    httpContext.TryAddHeader(Constants.CacheControlHeaderName,
-                        config.CacheControl.BuildHeaderValue());
-                }
-
-                if (config.UseCrossOriginResourcePolicy)
-                {
-                    httpContext.TryAddHeader(Constants.CrossOriginResourcePolicyHeaderName,
-                        config.CrossOriginResourcePolicy.BuildHeaderValue());
-                }
-            }
-
-            // Call the next middleware in the chain
-            await next(httpContext);
+            throw new ArgumentException($"Expected an instance of the {nameof(SecureHeadersMiddlewareConfiguration)} object.");
         }
 
-        private bool RequestShouldBeIgnored(PathString requestedPath)
+        if (!RequestShouldBeIgnored(httpContext.Request.Path))
         {
-            if (config.UrlsToIgnore.Count == 0)
+            if (config.UseHsts)
             {
-                return false;
+                httpContext.TryAddHeader(Constants.StrictTransportSecurityHeaderName,
+                    config.HstsConfiguration.BuildHeaderValue());
             }
 
-            return requestedPath.HasValue && config.UrlsToIgnore.Any(url => url.Equals(requestedPath.Value!, StringComparison.InvariantCulture));
+            if (config.UseXFrameOptions)
+            {
+                httpContext.TryAddHeader(Constants.XFrameOptionsHeaderName,
+                    config.XFrameOptionsConfiguration.BuildHeaderValue());
+            }
+
+            if (config.UseXssProtection)
+            {
+                httpContext.TryAddHeader(Constants.XssProtectionHeaderName,
+                    config.XssConfiguration.BuildHeaderValue());
+            }
+
+            if (config.UseXContentTypeOptions)
+            {
+                httpContext.TryAddHeader(Constants.XContentTypeOptionsHeaderName, "nosniff");
+            }
+
+            if (config.UseContentSecurityPolicyReportOnly)
+            {
+                if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
+                {
+                    _calculatedContentSecurityPolicy =
+                        config.ContentSecurityPolicyReportOnlyConfiguration.BuildHeaderValue();
+                }
+
+                httpContext.TryAddHeader(Constants.ContentSecurityPolicyReportOnlyHeaderName,
+                    _calculatedContentSecurityPolicy);
+            }
+            else if (config.UseContentSecurityPolicy)
+            {
+                if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
+                {
+                    _calculatedContentSecurityPolicy = config.ContentSecurityPolicyConfiguration.BuildHeaderValue();
+                }
+
+                httpContext.TryAddHeader(Constants.ContentSecurityPolicyHeaderName,
+                    _calculatedContentSecurityPolicy);
+            }
+
+            if (config.UseXContentSecurityPolicy)
+            {
+                httpContext.TryAddHeader(Constants.XContentSecurityPolicyHeaderName,
+                    config.ContentSecurityPolicyConfiguration.BuildHeaderValue());
+            }
+
+            if (config.UsePermittedCrossDomainPolicy)
+            {
+                httpContext.TryAddHeader(Constants.PermittedCrossDomainPoliciesHeaderName,
+                    config.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
+            }
+
+            if (config.UseReferrerPolicy)
+            {
+                httpContext.TryAddHeader(Constants.ReferrerPolicyHeaderName,
+                    config.ReferrerPolicy.BuildHeaderValue());
+            }
+
+            if (config.UseExpectCt)
+            {
+                httpContext.TryAddHeader(Constants.ExpectCtHeaderName,
+                    config.ExpectCt.BuildHeaderValue());
+            }
+
+            if (config.UseCacheControl)
+            {
+                httpContext.TryAddHeader(Constants.CacheControlHeaderName,
+                    config.CacheControl.BuildHeaderValue());
+            }
+
+            if (config.UseCrossOriginResourcePolicy)
+            {
+                httpContext.TryAddHeader(Constants.CrossOriginResourcePolicyHeaderName,
+                    config.CrossOriginResourcePolicy.BuildHeaderValue());
+            }
         }
+
+        // Call the next middleware in the chain
+        await next(httpContext);
     }
+
+    private bool RequestShouldBeIgnored(PathString requestedPath)
+    {
+        if (config.UrlsToIgnore.Count == 0)
+        {
+            return false;
+        }
+
+        return requestedPath.HasValue && config.UrlsToIgnore.Any(url => url.Equals(requestedPath.Value!, StringComparison.InvariantCulture));
+    }
+}
 }

--- a/src/SecureHeadersMiddleware.cs
+++ b/src/SecureHeadersMiddleware.cs
@@ -111,7 +111,7 @@ namespace OwaspHeaders.Core
             // Call the next middleware in the chain
             await next(httpContext);
         }
-        
+
         private bool RequestShouldBeIgnored(PathString requestedPath)
         {
             if (config.UrlsToIgnore.Count == 0)

--- a/tests/OwaspHeaders.Core.Tests/CustomHeaders/UrlIgnoreListTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/CustomHeaders/UrlIgnoreListTests.cs
@@ -37,7 +37,7 @@ namespace OwaspHeaders.Core.Tests.CustomHeaders
                         });
                 })
                 .Start();
-        
+
             TestServer = host.GetTestServer();
             TestServer.BaseAddress = new Uri("https://example.com/");
         }
@@ -46,18 +46,18 @@ namespace OwaspHeaders.Core.Tests.CustomHeaders
         public async Task Invoke_IgnoreList_Contains_TargetUrl_NoHeadersAdded()
         {
             // arrange
-        
+
             // Act
             var context = await TestServer.SendAsync(c =>
             {
                 c.Request.Path = UrlToIgnore;
                 c.Request.Method = HttpMethods.Get;
             });
-            
+
             // Assert
             Assert.NotNull(context.Response);
             Assert.NotNull(context.Response.Headers);
-            
+
             // Checking none of the default headers are present
             Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.StrictTransportSecurityHeaderName);
             Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.XFrameOptionsHeaderName);
@@ -68,23 +68,23 @@ namespace OwaspHeaders.Core.Tests.CustomHeaders
             Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.ReferrerPolicyHeaderName);
             Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.CacheControlHeaderName);
         }
-        
+
         [Fact]
         public async Task Invoke_IgnoreList_DoesntContain_TargetUrl_NoHeadersAdded()
         {
             // arrange
-        
+
             // Act
             var context = await TestServer.SendAsync(c =>
             {
                 c.Request.Path = UrlWontIgnore;
                 c.Request.Method = HttpMethods.Get;
             });
-            
+
             // Assert
             Assert.NotNull(context.Response);
             Assert.NotNull(context.Response.Headers);
-            
+
             // Checking none of the default headers are present
             Assert.Contains(context.Response.Headers, h => h.Key == Constants.StrictTransportSecurityHeaderName);
             Assert.Contains(context.Response.Headers, h => h.Key == Constants.XFrameOptionsHeaderName);

--- a/tests/OwaspHeaders.Core.Tests/CustomHeaders/UrlIgnoreListTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/CustomHeaders/UrlIgnoreListTests.cs
@@ -85,7 +85,7 @@ namespace OwaspHeaders.Core.Tests.CustomHeaders
             Assert.NotNull(context.Response);
             Assert.NotNull(context.Response.Headers);
 
-            // Checking none of the default headers are present
+            // Checking all of the default headers are present
             Assert.Contains(context.Response.Headers, h => h.Key == Constants.StrictTransportSecurityHeaderName);
             Assert.Contains(context.Response.Headers, h => h.Key == Constants.XFrameOptionsHeaderName);
             Assert.Contains(context.Response.Headers, h => h.Key == Constants.XssProtectionHeaderName);

--- a/tests/OwaspHeaders.Core.Tests/CustomHeaders/UrlIgnoreListTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/CustomHeaders/UrlIgnoreListTests.cs
@@ -1,0 +1,99 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace OwaspHeaders.Core.Tests.CustomHeaders
+{
+    public class UrlIgnoreListTests
+    {
+        private readonly string UrlToIgnore = "/ignore-me";
+        private readonly string UrlWontIgnore = "/do-not-ignore-me";
+        private readonly TestServer TestServer;
+
+        public UrlIgnoreListTests()
+        {
+            var host = new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder
+                        .UseTestServer()
+                        .ConfigureServices(services =>
+                        {
+                            services.AddRouting();
+                        })
+                        .Configure(app =>
+                        {
+                            app.UseRouting();
+                            app.UseSecureHeadersMiddleware(urlIgnoreList: [UrlToIgnore]);
+                            app.UseEndpoints(endpoints =>
+                            {
+                                endpoints.MapGet(UrlToIgnore, () =>
+                                    TypedResults.Text("Hello Tests"));
+                                endpoints.MapGet(UrlWontIgnore, () =>
+                                    TypedResults.Text("Hello Tests"));
+                            });
+                        });
+                })
+                .Start();
+        
+            TestServer = host.GetTestServer();
+            TestServer.BaseAddress = new Uri("https://example.com/");
+        }
+
+        [Fact]
+        public async Task Invoke_IgnoreList_Contains_TargetUrl_NoHeadersAdded()
+        {
+            // arrange
+        
+            // Act
+            var context = await TestServer.SendAsync(c =>
+            {
+                c.Request.Path = UrlToIgnore;
+                c.Request.Method = HttpMethods.Get;
+            });
+            
+            // Assert
+            Assert.NotNull(context.Response);
+            Assert.NotNull(context.Response.Headers);
+            
+            // Checking none of the default headers are present
+            Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.StrictTransportSecurityHeaderName);
+            Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.XFrameOptionsHeaderName);
+            Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.XssProtectionHeaderName);
+            Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.XContentTypeOptionsHeaderName);
+            Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.ContentSecurityPolicyHeaderName);
+            Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.PermittedCrossDomainPoliciesHeaderName);
+            Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.ReferrerPolicyHeaderName);
+            Assert.DoesNotContain(context.Response.Headers, h => h.Key == Constants.CacheControlHeaderName);
+        }
+        
+        [Fact]
+        public async Task Invoke_IgnoreList_DoesntContain_TargetUrl_NoHeadersAdded()
+        {
+            // arrange
+        
+            // Act
+            var context = await TestServer.SendAsync(c =>
+            {
+                c.Request.Path = UrlWontIgnore;
+                c.Request.Method = HttpMethods.Get;
+            });
+            
+            // Assert
+            Assert.NotNull(context.Response);
+            Assert.NotNull(context.Response.Headers);
+            
+            // Checking none of the default headers are present
+            Assert.Contains(context.Response.Headers, h => h.Key == Constants.StrictTransportSecurityHeaderName);
+            Assert.Contains(context.Response.Headers, h => h.Key == Constants.XFrameOptionsHeaderName);
+            Assert.Contains(context.Response.Headers, h => h.Key == Constants.XssProtectionHeaderName);
+            Assert.Contains(context.Response.Headers, h => h.Key == Constants.XContentTypeOptionsHeaderName);
+            Assert.Contains(context.Response.Headers, h => h.Key == Constants.ContentSecurityPolicyHeaderName);
+            Assert.Contains(context.Response.Headers, h => h.Key == Constants.PermittedCrossDomainPoliciesHeaderName);
+            Assert.Contains(context.Response.Headers, h => h.Key == Constants.ReferrerPolicyHeaderName);
+            Assert.Contains(context.Response.Headers, h => h.Key == Constants.CacheControlHeaderName);
+        }
+    }
+}

--- a/tests/OwaspHeaders.Core.Tests/OwaspHeaders.Core.Tests.csproj
+++ b/tests/OwaspHeaders.Core.Tests/OwaspHeaders.Core.Tests.csproj
@@ -15,6 +15,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    
+    <!--
+      Currently locked to version 8, as we support .NET 8 as a target platform here.
+      As all of the SDKs are backward compatible, we can leave this here until Microsoft
+      drops support for .NET 8.
+    -->
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/tests/OwaspHeaders.Core.Tests/OwaspHeaders.Core.Tests.csproj
+++ b/tests/OwaspHeaders.Core.Tests/OwaspHeaders.Core.Tests.csproj
@@ -15,6 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
@@ -89,4 +89,60 @@ public class SecureHeadersMiddlewareTests
         Assert.True(response.UseCrossOriginResourcePolicy);
         Assert.Equal("same-origin", response.CrossOriginResourcePolicy.BuildHeaderValue());
     }
+
+    [Fact]
+    public void BuildDefaultConfiguration_WhenValidIgnoreListSupplied_Returns_Valid_Configuration()
+    {
+        // Arrange
+        var ignoreList = new List<string> { "/ignore" };
+
+        // Act
+        var response = SecureHeadersMiddlewareExtensions.BuildDefaultConfiguration(ignoreList);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.IsType<SecureHeadersMiddlewareConfiguration>(response);
+
+        // HSTS
+        Assert.True(response.UseHsts);
+        Assert.Equal("max-age=31536000;includeSubDomains", response.HstsConfiguration.BuildHeaderValue());
+
+        // X-Frame-Options
+        Assert.True(response.UseXFrameOptions);
+        Assert.Equal("DENY", response.XFrameOptionsConfiguration.BuildHeaderValue());
+
+        // X-Content-Type-Options
+        Assert.True(response.UseXContentTypeOptions);
+        // Can't easily assert the value here, as it's set in the InvokeAsync for the middleware
+
+        // Content-Security-Policy
+        Assert.True(response.UseContentSecurityPolicy);
+        Assert.Equal("script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests;",
+            response.ContentSecurityPolicyConfiguration.BuildHeaderValue());
+
+        // X-Permitted-Cross-Domain-Policies
+        Assert.True(response.UsePermittedCrossDomainPolicy);
+        Assert.Equal("none;", response.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
+
+        // Referrer-Policy
+        Assert.True(response.UseReferrerPolicy);
+        Assert.Equal("no-referrer", response.ReferrerPolicy.BuildHeaderValue());
+
+        // Cache-Control
+        Assert.True(response.UseCacheControl);
+        Assert.Equal("max-age=0,no-store", response.CacheControl.BuildHeaderValue());
+
+        // X-XSS-Protection
+        Assert.True(response.UseXssProtection);
+        Assert.Equal("0", response.XssConfiguration.BuildHeaderValue());
+
+        // Cross-Origin Resource Policy
+        Assert.True(response.UseCrossOriginResourcePolicy);
+        Assert.Equal("same-origin", response.CrossOriginResourcePolicy.BuildHeaderValue());
+        
+        // Ignore List
+        Assert.NotNull(response.UrlsToIgnore);
+        Assert.NotEmpty(response.UrlsToIgnore);
+        Assert.Contains(ignoreList.First(), response.UrlsToIgnore);
+    }
 }

--- a/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
@@ -46,48 +46,13 @@ public class SecureHeadersMiddlewareTests
         // Arrange
 
         // Act
-        var response = SecureHeadersMiddlewareExtensions.BuildDefaultConfiguration();
+        var middlewareConfiguration = SecureHeadersMiddlewareExtensions.BuildDefaultConfiguration();
 
         // Assert
-        Assert.NotNull(response);
-        Assert.IsType<SecureHeadersMiddlewareConfiguration>(response);
+        Assert.NotNull(middlewareConfiguration);
+        Assert.IsType<SecureHeadersMiddlewareConfiguration>(middlewareConfiguration);
 
-        // HSTS
-        Assert.True(response.UseHsts);
-        Assert.Equal("max-age=31536000;includeSubDomains", response.HstsConfiguration.BuildHeaderValue());
-
-        // X-Frame-Options
-        Assert.True(response.UseXFrameOptions);
-        Assert.Equal("DENY", response.XFrameOptionsConfiguration.BuildHeaderValue());
-
-        // X-Content-Type-Options
-        Assert.True(response.UseXContentTypeOptions);
-        // Can't easily assert the value here, as it's set in the InvokeAsync for the middleware
-
-        // Content-Security-Policy
-        Assert.True(response.UseContentSecurityPolicy);
-        Assert.Equal("script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests;",
-            response.ContentSecurityPolicyConfiguration.BuildHeaderValue());
-
-        // X-Permitted-Cross-Domain-Policies
-        Assert.True(response.UsePermittedCrossDomainPolicy);
-        Assert.Equal("none;", response.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
-
-        // Referrer-Policy
-        Assert.True(response.UseReferrerPolicy);
-        Assert.Equal("no-referrer", response.ReferrerPolicy.BuildHeaderValue());
-
-        // Cache-Control
-        Assert.True(response.UseCacheControl);
-        Assert.Equal("max-age=0,no-store", response.CacheControl.BuildHeaderValue());
-
-        // X-XSS-Protection
-        Assert.True(response.UseXssProtection);
-        Assert.Equal("0", response.XssConfiguration.BuildHeaderValue());
-
-        // Cross-Origin Resource Policy
-        Assert.True(response.UseCrossOriginResourcePolicy);
-        Assert.Equal("same-origin", response.CrossOriginResourcePolicy.BuildHeaderValue());
+        AssertHeadersInResponse(middlewareConfiguration);
     }
 
     [Fact]
@@ -97,52 +62,77 @@ public class SecureHeadersMiddlewareTests
         var ignoreList = new List<string> { "/ignore" };
 
         // Act
-        var response = SecureHeadersMiddlewareExtensions.BuildDefaultConfiguration(ignoreList);
+        var middlewareConfiguration = SecureHeadersMiddlewareExtensions.BuildDefaultConfiguration(ignoreList);
 
         // Assert
-        Assert.NotNull(response);
-        Assert.IsType<SecureHeadersMiddlewareConfiguration>(response);
+        Assert.NotNull(middlewareConfiguration);
+        Assert.IsType<SecureHeadersMiddlewareConfiguration>(middlewareConfiguration);
 
+        AssertHeadersInResponse(middlewareConfiguration);
+
+        // Ignore List
+        Assert.NotNull(middlewareConfiguration.UrlsToIgnore);
+        Assert.NotEmpty(middlewareConfiguration.UrlsToIgnore);
+        Assert.Contains(ignoreList.First(), middlewareConfiguration.UrlsToIgnore);
+    }
+
+    [Fact]
+    public void BuildDefaultConfiguration_WhenInvalidIgnoreListSupplied_Returns_Valid_Configuration_With_Empty_IgnoreList()
+    {
+        // Arrange
+        List<string> ignoreList = null;
+
+        // Act
+        var middlewareConfiguration = SecureHeadersMiddlewareExtensions.BuildDefaultConfiguration(ignoreList);
+
+        // Assert
+        Assert.NotNull(middlewareConfiguration);
+        Assert.IsType<SecureHeadersMiddlewareConfiguration>(middlewareConfiguration);
+
+        AssertHeadersInResponse(middlewareConfiguration);
+
+        // Ignore List
+        Assert.NotNull(middlewareConfiguration.UrlsToIgnore);
+        Assert.Empty(middlewareConfiguration.UrlsToIgnore);
+    }
+
+    private void AssertHeadersInResponse(SecureHeadersMiddlewareConfiguration middlewareConfiguration)
+    {
         // HSTS
-        Assert.True(response.UseHsts);
-        Assert.Equal("max-age=31536000;includeSubDomains", response.HstsConfiguration.BuildHeaderValue());
+        Assert.True(middlewareConfiguration.UseHsts);
+        Assert.Equal("max-age=31536000;includeSubDomains", middlewareConfiguration.HstsConfiguration.BuildHeaderValue());
 
         // X-Frame-Options
-        Assert.True(response.UseXFrameOptions);
-        Assert.Equal("DENY", response.XFrameOptionsConfiguration.BuildHeaderValue());
+        Assert.True(middlewareConfiguration.UseXFrameOptions);
+        Assert.Equal("DENY", middlewareConfiguration.XFrameOptionsConfiguration.BuildHeaderValue());
 
         // X-Content-Type-Options
-        Assert.True(response.UseXContentTypeOptions);
+        Assert.True(middlewareConfiguration.UseXContentTypeOptions);
         // Can't easily assert the value here, as it's set in the InvokeAsync for the middleware
 
         // Content-Security-Policy
-        Assert.True(response.UseContentSecurityPolicy);
+        Assert.True(middlewareConfiguration.UseContentSecurityPolicy);
         Assert.Equal("script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests;",
-            response.ContentSecurityPolicyConfiguration.BuildHeaderValue());
+            middlewareConfiguration.ContentSecurityPolicyConfiguration.BuildHeaderValue());
 
         // X-Permitted-Cross-Domain-Policies
-        Assert.True(response.UsePermittedCrossDomainPolicy);
-        Assert.Equal("none;", response.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
+        Assert.True(middlewareConfiguration.UsePermittedCrossDomainPolicy);
+        Assert.Equal("none;", middlewareConfiguration.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
 
         // Referrer-Policy
-        Assert.True(response.UseReferrerPolicy);
-        Assert.Equal("no-referrer", response.ReferrerPolicy.BuildHeaderValue());
+        Assert.True(middlewareConfiguration.UseReferrerPolicy);
+        Assert.Equal("no-referrer", middlewareConfiguration.ReferrerPolicy.BuildHeaderValue());
 
         // Cache-Control
-        Assert.True(response.UseCacheControl);
-        Assert.Equal("max-age=0,no-store", response.CacheControl.BuildHeaderValue());
+        Assert.True(middlewareConfiguration.UseCacheControl);
+        Assert.Equal("max-age=0,no-store", middlewareConfiguration.CacheControl.BuildHeaderValue());
 
         // X-XSS-Protection
-        Assert.True(response.UseXssProtection);
-        Assert.Equal("0", response.XssConfiguration.BuildHeaderValue());
+        Assert.True(middlewareConfiguration.UseXssProtection);
+        Assert.Equal("0", middlewareConfiguration.XssConfiguration.BuildHeaderValue());
 
         // Cross-Origin Resource Policy
-        Assert.True(response.UseCrossOriginResourcePolicy);
-        Assert.Equal("same-origin", response.CrossOriginResourcePolicy.BuildHeaderValue());
-
-        // Ignore List
-        Assert.NotNull(response.UrlsToIgnore);
-        Assert.NotEmpty(response.UrlsToIgnore);
-        Assert.Contains(ignoreList.First(), response.UrlsToIgnore);
+        Assert.True(middlewareConfiguration.UseCrossOriginResourcePolicy);
+        Assert.Equal("same-origin", middlewareConfiguration.CrossOriginResourcePolicy.BuildHeaderValue());
     }
 }

--- a/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
@@ -139,7 +139,7 @@ public class SecureHeadersMiddlewareTests
         // Cross-Origin Resource Policy
         Assert.True(response.UseCrossOriginResourcePolicy);
         Assert.Equal("same-origin", response.CrossOriginResourcePolicy.BuildHeaderValue());
-        
+
         // Ignore List
         Assert.NotNull(response.UrlsToIgnore);
         Assert.NotEmpty(response.UrlsToIgnore);

--- a/tests/OwaspHeaders.Core.Tests/packages.lock.json
+++ b/tests/OwaspHeaders.Core.Tests/packages.lock.json
@@ -8,6 +8,15 @@
         "resolved": "6.0.2",
         "contentHash": "bJShQ6uWRTQ100ZeyiMqcFlhP7WJ+bCuabUs885dJiBEzMsJMSFr7BOyeCw4rgvQokteGi5rKQTlkhfQPUXg2A=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "Rk6Ai9bFf1KubVY5oEbEPN5fiKWW2oeU+easjokyUqqYyTHRsXlkjFeMvwecgoXsoTfXMSwEHzJp8FCjQcyYTQ==",
+        "dependencies": {
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[17.12.0, )",
@@ -61,6 +70,11 @@
         "type": "Transitive",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -118,6 +132,15 @@
         "resolved": "6.0.2",
         "contentHash": "bJShQ6uWRTQ100ZeyiMqcFlhP7WJ+bCuabUs885dJiBEzMsJMSFr7BOyeCw4rgvQokteGi5rKQTlkhfQPUXg2A=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "Rk6Ai9bFf1KubVY5oEbEPN5fiKWW2oeU+easjokyUqqYyTHRsXlkjFeMvwecgoXsoTfXMSwEHzJp8FCjQcyYTQ==",
+        "dependencies": {
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[17.12.0, )",
@@ -171,6 +194,11 @@
         "type": "Transitive",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",


### PR DESCRIPTION
## Rationale for this PR

This PR attempts to fix #141 by adding the ability to supply a list of URLs that the middleware should ignore&mdash;disabling the middleware when those URLs are requested.

This PR closes #141 

The following is a [minimal code sample](https://gaprogman.github.io/OwaspHeaders.Core/Minimal-Code-Sample/) for the new feature:

```csharp
// in Program.cs
var urlsToIgnore = new List<string> { "/url-one", "/url-two" };
app.UseSecureHeadersMiddleware(urlIgnoreList: urlsToIgnore);
```

Using the above example:

- Requests to either `/url-one` or `/url-two` will be ignored by the middleware, meaning not secure headers will be added to the response
- Requests to any other URL will still be processed by the middleware

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [ ✅ ] I have added tests to the OwaspHeaders.Core.Tests project
- [ ✅ ] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [ ✅ ] I have ensured that the code coverage has not dropped below 65%
- [ ✅ ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

#### Optional

- [ ❎ ] I have documented the new feature in the docs directory
- [ ✅ ] I have provided a code sample, showing how someone could use the new code

### Any Other Information

There will be a separate issue and PR combo for documenting this feature.
