### PR TITLE
Fix .NET SDK mismatches in actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,14 +85,27 @@ jobs:
     # to build your code.
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
 
+    - if: matrix.build-mode == 'manual'
+    # The following steps are based on the content from the following URLs:
+    # https://resources.github.com/learn/pathways/security/intermediate/codeql-advanced-setup/
+    # https://learn.microsoft.com/en-us/dotnet/devops/dotnet-secure-github-action
+
+    # The NuGet package we're building supports both .NET 8 and .NET 9, so we need
+    # to install both so that we can build the project.
+      name: Setup .NET SDK 8.0
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
+      with:
+        dotnet-version: '8.0.x'
+
+    - if: matrix.build-mode == 'manual'
       # The following steps are based on the content from the following URLs:
       # https://resources.github.com/learn/pathways/security/intermediate/codeql-advanced-setup/
       # https://learn.microsoft.com/en-us/dotnet/devops/dotnet-secure-github-action
+
       # We currently (as of December 4th, 2024) need to build manually, because the Ubunutu images
       # don't have .NET 9 installed on them.
-      name: Setup .NET
+      name: Setup .NET SDK 9.0
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
       with:
         dotnet-version: '9.0.x'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -76,7 +76,14 @@ jobs:
       with:
         fetch-depth: 0
       
-    - name: Setup .NET SDK
+    # The NuGet package we're building supports both .NET 8 and .NET 9, so we need
+    # to install both so that we can build the project.
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Setup .NET SDK 9.0
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
       with:
         dotnet-version: '9.0.x'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,7 +25,14 @@ jobs:
       with:
         fetch-depth: 1
 
-    - name: Setup .NET
+    # The NuGet package we're building supports both .NET 8 and .NET 9, so we need
+    # to install both so that we can work with the project.
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Setup .NET SDK 9.0
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
       with:
         dotnet-version: '9.0.x'
@@ -48,7 +55,14 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup .NET SDK
+    # The NuGet package we're building supports both .NET 8 and .NET 9, so we need
+    # to install both so that we can build the project.
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Setup .NET SDK 9.0
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
       with:
         dotnet-version: '9.0.x'
@@ -77,7 +91,7 @@ jobs:
         fetch-depth: 0
       
     # The NuGet package we're building supports both .NET 8 and .NET 9, so we need
-    # to install both so that we can build the project.
+    # to install both so that we can run the tests.
     - name: Setup .NET 8.0
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
       with:
@@ -120,7 +134,14 @@ jobs:
       with:
         fetch-depth: 0
       
-    - name: Setup .NET SDK
+    # The NuGet package we're building supports both .NET 8 and .NET 9, so we need
+    # to install both so that we can create the NuGet package.
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Setup .NET SDK 9.0
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
       with:
         dotnet-version: '9.0.x'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,14 @@ jobs:
       with:
         fetch-depth: 0
       
-    - name: Setup .NET SDK
+    # The NuGet package we're building supports both .NET 8 and .NET 9, so we need
+    # to install both so that we can build the project.
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Setup .NET SDK 9.0
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
       with:
         dotnet-version: '9.0.x'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,14 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup .NET SDK
+    # The NuGet package we're building supports both .NET 8 and .NET 9, so we need
+    # to install both so that we can build the project.
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Setup .NET SDK 9.0
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
       with:
         dotnet-version: '9.0.x'
@@ -50,7 +57,7 @@ jobs:
         fetch-depth: 0
       
     # The NuGet package we're building supports both .NET 8 and .NET 9, so we need
-    # to install both so that we can build the project.
+    # to install both so that we can test the project.
     - name: Setup .NET 8.0
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
       with:
@@ -76,7 +83,14 @@ jobs:
       with:
         fetch-depth: 0
       
-    - name: Setup .NET SDK
+    # The NuGet package we're building supports both .NET 8 and .NET 9, so we need
+    # to install both so that we can create the NuGet package.
+    - name: Setup .NET 8.0
+      uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Setup .NET SDK 9.0
       uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
       with:
         dotnet-version: '9.0.x'

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>OwaspHeaders.Core</PackageId>
-    <Version>9.4.2</Version>
+    <Version>9.4.3</Version>
     <Authors>Jamie Taylor</Authors>
     <Company>RJJ Software Ltd</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Rationale for this PR

This project builds for both .NET 8 and .NET 9 (at the time of PR creation), however some GitHub actions where only making use of .NET 9. The SDKs _should_ be backward compatible, but it has been seen (across multiple different actions) that this is not the case. An example is a recent (at the time of PR creation) [run of the CodeQL analysis task](https://github.com/GaProgMan/OwaspHeaders.Core/actions/runs/12271100297/job/34237402033) which fails for the following error (which has been cleaned up for convenience):

```plaintext
error : You must install or update .NET to run this application. 
error : Architecture: x64 
error : Framework: 'Microsoft.AspNetCore.App', version '8.0.0' (x64) 
error : The following frameworks were found: 
error : 9.0.0 at [/usr/share/dotnet/shared/Microsoft.AspNetCore.App] 
```

The relevant lines of which are:

- `You must install or update .NET to run this application.` (first line of above)
- `error : The following frameworks were found: 9.0.0 at [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]` (the final few lines, combined for convenience)

The fix included in this PR is to explicitly install the relevant .NET SDKs (at the time of PR creation, both .NET 8 and 9) in each action where it is required.

### Note

This might be a temporary problem (see: https://github.com/actions/runner-images/issues/10973#issuecomment-2501333968), but it's also better to be explicit about the dependencies used. So these changes (assuming they work, and Github actions can only be tested ON GitHub) will likely stay in place, being updated when new SDKs are required or runtimes are supported by the project.

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [❓] I have added tests to the OwaspHeaders.Core.Tests project
- [✅] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [✅] I have ensured that the code coverage has not dropped below 65%
- [✅] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

#### Optional

- [❓] I have documented the new feature in the docs directory
- [❓] I have provided a code sample, showing how someone could use the new code

### Any Other Information

This section is optional, but it might be useful to list any other information you think is relevant.
