### PR TITLE
Fix for images not displaying in attestations docs

### DIFF
--- a/docs/attestations.md
+++ b/docs/attestations.md
@@ -28,7 +28,7 @@ This step will provide an attestation for the commit which caused the PR build t
 
 When the build workflow completes, there will be a section in the job summary called "Create the NuGet package for PR-level user testing summary" (see: [this link](https://github.com/GaProgMan/OwaspHeaders.Core/actions/runs/12473647282#summary-34814538093) or the following screenshot for an example)
 
-![](./assets/images/attestations/pr-created.jpg)
+![](../assets/images/attestations/pr-created.jpg)
 
 Clicking the link under "Attestation created" will take you to the attestation for the particular build of OwaspHeaders.Core.
 
@@ -44,7 +44,7 @@ In order to manually verify the nupkg file, you will need to download the genera
   - The file will be called "OwaspHeaders.Core"
   - See the following screenshot:
 
-![](./assets/images/attestations/artifacts.jpg)
+![](../assets/images/attestations/artifacts.jpg)
 
 - Extract the zip file
   - You can using your favourite unarchiver
@@ -95,7 +95,7 @@ This step will provide an attestation for the commit which caused the NuGet rele
 
 When the build workflow completes, there will be a section in the job summary called "Create the NuGet package for PR-level user testing summary" (see: [this link](https://github.com/GaProgMan/OwaspHeaders.Core/actions/runs/12474053355) or the following screenshot for an example)
 
-![](./assets/images/attestations/release-created.jpg)
+![](../assets/images/attestations/release-created.jpg)
 
 Clicking the link under "Attestation created" will take you to the attestation for the particular build of OwaspHeaders.Core.
 


### PR DESCRIPTION
## Rationale for this PR

This PR fixes images not appearing in the attestation docs page.

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [❓] I have added tests to the OwaspHeaders.Core.Tests project
- [❓] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [❓] I have ensured that the code coverage has not dropped below 65%
- [❓] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

#### Optional

- [❓] I have documented the new feature in the docs directory
- [❓] I have provided a code sample, showing how someone could use the new code

### Any Other Information

This section is optional, but it might be useful to list any other information you think is relevant.
