### PR TITLE
Header Caching

### DIFF
--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -9,6 +9,7 @@ public static class Constants
     public const string XssProtectionHeaderName = "X-XSS-Protection";
 
     public const string XContentTypeOptionsHeaderName = "X-Content-Type-Options";
+    public const string XContentTypeOptionsValue = "nosniff";
 
     public const string ContentSecurityPolicyHeaderName = "Content-Security-Policy";
 

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>OwaspHeaders.Core</PackageId>
-    <Version>9.5.0</Version>
+    <Version>9.6.0</Version>
     <Authors>Jamie Taylor</Authors>
     <Company>RJJ Software Ltd</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/SecureHeadersMiddleware.cs
+++ b/src/SecureHeadersMiddleware.cs
@@ -9,141 +9,141 @@ namespace OwaspHeaders.Core;
 /// </summary>
 public class SecureHeadersMiddleware()
 {
-    private string _calculatedContentSecurityPolicy;
-    private readonly Dictionary<string, string> _headers;
-    private readonly RequestDelegate _next;
-    private readonly SecureHeadersMiddlewareConfiguration _config;
-    
-    public SecureHeadersMiddleware(RequestDelegate next, SecureHeadersMiddlewareConfiguration config) : this()
+private string _calculatedContentSecurityPolicy;
+private readonly Dictionary<string, string> _headers;
+private readonly RequestDelegate _next;
+private readonly SecureHeadersMiddlewareConfiguration _config;
+
+public SecureHeadersMiddleware(RequestDelegate next, SecureHeadersMiddlewareConfiguration config) : this()
+{
+    _config = config;
+    _next = next;
+    _headers = new Dictionary<string, string>();
+}
+
+/// <summary>
+/// The main task of the middleware. This will be invoked whenever
+/// the middleware fires
+/// </summary>
+/// <param name="httpContext">The <see cref="HttpContext" /> for the current request or response</param>
+/// <returns></returns>
+public async Task InvokeAsync(HttpContext httpContext)
+{
+    if (_config == null)
     {
-        _config = config;
-        _next = next;
-        _headers = new Dictionary<string, string>();
+        throw new ArgumentException(
+            $"Expected an instance of the {nameof(SecureHeadersMiddlewareConfiguration)} object.");
     }
 
-    /// <summary>
-    /// The main task of the middleware. This will be invoked whenever
-    /// the middleware fires
-    /// </summary>
-    /// <param name="httpContext">The <see cref="HttpContext" /> for the current request or response</param>
-    /// <returns></returns>
-    public async Task InvokeAsync(HttpContext httpContext)
+    if (!RequestShouldBeIgnored(httpContext.Request.Path))
     {
-        if (_config == null)
+        if (_headers.Count == 0)
         {
-            throw new ArgumentException(
-                $"Expected an instance of the {nameof(SecureHeadersMiddlewareConfiguration)} object.");
+            GenerateRelevantHeaders();
         }
 
-        if (!RequestShouldBeIgnored(httpContext.Request.Path))
+        foreach (var (key, value) in _headers)
         {
-            if (_headers.Count == 0)
-            {
-                GenerateRelevantHeaders();
-            }
-            
-            foreach (var (key, value) in _headers)
-            {
-                httpContext.TryAddHeader(key, value);
-            }
-        }
-
-        // Call the next middleware in the chain
-        await _next(httpContext);
-    }
-
-    private void GenerateRelevantHeaders()
-    {
-        if (_config.UseHsts)
-        {
-            _headers.TryAdd(Constants.StrictTransportSecurityHeaderName,
-                _config.HstsConfiguration.BuildHeaderValue());
-        }
-
-        if (_config.UseXFrameOptions)
-        {
-            _headers.TryAdd(Constants.XFrameOptionsHeaderName,
-                _config.XFrameOptionsConfiguration.BuildHeaderValue());
-        }
-
-        if (_config.UseXssProtection)
-        {
-            _headers.TryAdd(Constants.XssProtectionHeaderName,
-                _config.XssConfiguration.BuildHeaderValue());
-        }
-
-        if (_config.UseXContentTypeOptions)
-        {
-            _headers.TryAdd(Constants.XContentTypeOptionsHeaderName, Constants.XContentTypeOptionsValue);
-        }
-
-        if (_config.UseContentSecurityPolicyReportOnly)
-        {
-            if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
-            {
-                _calculatedContentSecurityPolicy =
-                    _config.ContentSecurityPolicyReportOnlyConfiguration.BuildHeaderValue();
-            }
-
-            _headers.TryAdd(Constants.ContentSecurityPolicyReportOnlyHeaderName,
-                _calculatedContentSecurityPolicy);
-        }
-        else if (_config.UseContentSecurityPolicy)
-        {
-            if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
-            {
-                _calculatedContentSecurityPolicy = _config.ContentSecurityPolicyConfiguration.BuildHeaderValue();
-            }
-
-            _headers.TryAdd(Constants.ContentSecurityPolicyHeaderName,
-                _calculatedContentSecurityPolicy);
-        }
-
-        if (_config.UseXContentSecurityPolicy)
-        {
-            _headers.TryAdd(Constants.XContentSecurityPolicyHeaderName,
-                _config.ContentSecurityPolicyConfiguration.BuildHeaderValue());
-        }
-
-        if (_config.UsePermittedCrossDomainPolicy)
-        {
-            _headers.TryAdd(Constants.PermittedCrossDomainPoliciesHeaderName,
-                _config.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
-        }
-
-        if (_config.UseReferrerPolicy)
-        {
-            _headers.TryAdd(Constants.ReferrerPolicyHeaderName,
-                _config.ReferrerPolicy.BuildHeaderValue());
-        }
-
-        if (_config.UseExpectCt)
-        {
-            _headers.TryAdd(Constants.ExpectCtHeaderName,
-                _config.ExpectCt.BuildHeaderValue());
-        }
-
-        if (_config.UseCacheControl)
-        {
-            _headers.TryAdd(Constants.CacheControlHeaderName,
-                _config.CacheControl.BuildHeaderValue());
-        }
-
-        if (_config.UseCrossOriginResourcePolicy)
-        {
-            _headers.TryAdd(Constants.CrossOriginResourcePolicyHeaderName,
-                _config.CrossOriginResourcePolicy.BuildHeaderValue());
+            httpContext.TryAddHeader(key, value);
         }
     }
 
-    private bool RequestShouldBeIgnored(PathString requestedPath)
+    // Call the next middleware in the chain
+    await _next(httpContext);
+}
+
+private void GenerateRelevantHeaders()
+{
+    if (_config.UseHsts)
     {
-        if (_config.UrlsToIgnore.Count == 0)
+        _headers.TryAdd(Constants.StrictTransportSecurityHeaderName,
+            _config.HstsConfiguration.BuildHeaderValue());
+    }
+
+    if (_config.UseXFrameOptions)
+    {
+        _headers.TryAdd(Constants.XFrameOptionsHeaderName,
+            _config.XFrameOptionsConfiguration.BuildHeaderValue());
+    }
+
+    if (_config.UseXssProtection)
+    {
+        _headers.TryAdd(Constants.XssProtectionHeaderName,
+            _config.XssConfiguration.BuildHeaderValue());
+    }
+
+    if (_config.UseXContentTypeOptions)
+    {
+        _headers.TryAdd(Constants.XContentTypeOptionsHeaderName, Constants.XContentTypeOptionsValue);
+    }
+
+    if (_config.UseContentSecurityPolicyReportOnly)
+    {
+        if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
         {
-            return false;
+            _calculatedContentSecurityPolicy =
+                _config.ContentSecurityPolicyReportOnlyConfiguration.BuildHeaderValue();
         }
 
-        return requestedPath.HasValue &&
-               _config.UrlsToIgnore.Any(url => url.Equals(requestedPath.Value!, StringComparison.InvariantCulture));
+        _headers.TryAdd(Constants.ContentSecurityPolicyReportOnlyHeaderName,
+            _calculatedContentSecurityPolicy);
     }
+    else if (_config.UseContentSecurityPolicy)
+    {
+        if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
+        {
+            _calculatedContentSecurityPolicy = _config.ContentSecurityPolicyConfiguration.BuildHeaderValue();
+        }
+
+        _headers.TryAdd(Constants.ContentSecurityPolicyHeaderName,
+            _calculatedContentSecurityPolicy);
+    }
+
+    if (_config.UseXContentSecurityPolicy)
+    {
+        _headers.TryAdd(Constants.XContentSecurityPolicyHeaderName,
+            _config.ContentSecurityPolicyConfiguration.BuildHeaderValue());
+    }
+
+    if (_config.UsePermittedCrossDomainPolicy)
+    {
+        _headers.TryAdd(Constants.PermittedCrossDomainPoliciesHeaderName,
+            _config.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
+    }
+
+    if (_config.UseReferrerPolicy)
+    {
+        _headers.TryAdd(Constants.ReferrerPolicyHeaderName,
+            _config.ReferrerPolicy.BuildHeaderValue());
+    }
+
+    if (_config.UseExpectCt)
+    {
+        _headers.TryAdd(Constants.ExpectCtHeaderName,
+            _config.ExpectCt.BuildHeaderValue());
+    }
+
+    if (_config.UseCacheControl)
+    {
+        _headers.TryAdd(Constants.CacheControlHeaderName,
+            _config.CacheControl.BuildHeaderValue());
+    }
+
+    if (_config.UseCrossOriginResourcePolicy)
+    {
+        _headers.TryAdd(Constants.CrossOriginResourcePolicyHeaderName,
+            _config.CrossOriginResourcePolicy.BuildHeaderValue());
+    }
+}
+
+private bool RequestShouldBeIgnored(PathString requestedPath)
+{
+    if (_config.UrlsToIgnore.Count == 0)
+    {
+        return false;
+    }
+
+    return requestedPath.HasValue &&
+           _config.UrlsToIgnore.Any(url => url.Equals(requestedPath.Value!, StringComparison.InvariantCulture));
+}
 }


### PR DESCRIPTION
## Rationale for this PR

This PR adds support for caching the calculated header values.

Each time that the middleware is called (on every request-response cycle), the following happens:

- [check if the config is null](https://github.com/GaProgMan/OwaspHeaders.Core/compare/main...feature/header-caching#diff-407f268da2b6db277062a0a9c2f3363de11426571c904ee6bf6f4c7ec391e226R32)
- [check if the URL should be ignored](https://github.com/GaProgMan/OwaspHeaders.Core/compare/main...feature/header-caching#diff-407f268da2b6db277062a0a9c2f3363de11426571c904ee6bf6f4c7ec391e226R38)
- [check whether headers have been calculated previously](https://github.com/GaProgMan/OwaspHeaders.Core/compare/main...feature/header-caching#diff-407f268da2b6db277062a0a9c2f3363de11426571c904ee6bf6f4c7ec391e226R40)
  - [generate and cache headers](https://github.com/GaProgMan/OwaspHeaders.Core/compare/main...feature/header-caching#diff-407f268da2b6db277062a0a9c2f3363de11426571c904ee6bf6f4c7ec391e226R42)
- [add pre-calculated headers](https://github.com/GaProgMan/OwaspHeaders.Core/compare/main...feature/header-caching#diff-407f268da2b6db277062a0a9c2f3363de11426571c904ee6bf6f4c7ec391e226R47)

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [ :question: ] I have added tests to the OwaspHeaders.Core.Tests project
- [ :white_check_mark: ] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [ :white_check_mark: ] I have ensured that the code coverage has not dropped below 65%
- [ :white_check_mark: ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

#### Optional

- [ :question: ] I have documented the new feature in the docs directory
- [ :question: ] I have provided a code sample, showing how someone could use the new code

### Any Other Information

This section is optional, but it might be useful to list any other information you think is relevant.
