### PR TITLE
Bugfix/editorconfig bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This changelog represents all of the major (i.e. breaking) changes made to the OwaspHeaders.Core project since it's inception. Early in the repo's development, GitHub's "releases" where used to release builds of the code repo. However shortly after it's inception, builds and releases where moved to [AppVeyor](https://ci.appveyor.com/project/GaProgMan/owaspheaders-core). Because of this, the releases on the GitHub repo became stale.
+This changelog represents all the major (i.e. breaking) changes made to the OwaspHeaders.Core project since it's inception. Early in the repo's development, GitHub's "releases" where used to release builds of the code repo. However shortly after it's inception, builds and releases where moved to [AppVeyor](https://ci.appveyor.com/project/GaProgMan/owaspheaders-core). Because of this, the releases on the GitHub repo became stale.
 
 ## TL;DR
 
@@ -21,6 +21,10 @@ This changelog represents all of the major (i.e. breaking) changes made to the O
 This version dropped support for .NET 6 and .NET 7, as they are no longer supported by Microsoft. It also added support for .NET 9.
 
 All projects in the [GitHub repo](https://github.com/GaProgMan/OwaspHeaders.Core) now build and run with either .NET 8 or .NET 9, whichever is present (deferring to the highest version number if both are present). As of November 19th, 2024 there are no new features in Version 9, so if you still need to use the NuGet package with .NET 6 or 7 please use Version 8 of the package.
+
+#### Version 9.6.x
+
+This version saw the addition of a number of _very_ small changes to the middleware's `Invoke` method which aimed to increase efficiency, reduce working memory usage, and increase execution speed. 
 
 #### Version 9.5.x
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@ nav_order: 7
 
 # Changelog
 
-This changelog represents all of the major (i.e. breaking) changes made to the OwaspHeaders.Core project since it's inception. Early in the repo's development, GitHub's "releases" where used to release builds of the code repo. However shortly after it's inception, builds and releases where moved to [AppVeyor](https://ci.appveyor.com/project/GaProgMan/owaspheaders-core). Because of this, the releases on the GitHub repo became stale.
+This changelog represents all the major (i.e. breaking) changes made to the OwaspHeaders.Core project since it's inception. Early in the repo's development, GitHub's "releases" where used to release builds of the code repo. However shortly after it's inception, builds and releases where moved to [AppVeyor](https://ci.appveyor.com/project/GaProgMan/owaspheaders-core). Because of this, the releases on the GitHub repo became stale.
 
 ## TL;DR
 
@@ -28,6 +28,9 @@ This version dropped support for .NET 6 and .NET 7, as they are no longer suppor
 
 All projects in the [GitHub repo](https://github.com/GaProgMan/OwaspHeaders.Core) now build and run with either .NET 8 or .NET 9, whichever is present (deferring to the highest version number if both are present). As of November 19th, 2024 there are no new features in Version 9, so if you still need to use the NuGet package with .NET 6 or 7 please use Version 8 of the package.
 
+#### Version 9.6.x
+
+This version saw the addition of a number of _very_ small changes to the middleware's `Invoke` method which aimed to increase efficiency, reduce working memory usage, and increase execution speed.
 #### Version 9.5.x
 
 This version saw the addition of attestation generation on both a per PR-build and Release basis. See the [Attestations](https://gaprogman.github.io/OwaspHeaders.Core/attestations) page of the documentation to read about how you can verify the attestations per build or release.

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>OwaspHeaders.Core</PackageId>
-    <Version>9.6.0</Version>
+    <Version>9.6.1</Version>
     <Authors>Jamie Taylor</Authors>
     <Company>RJJ Software Ltd</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/SecureHeadersMiddleware.cs
+++ b/src/SecureHeadersMiddleware.cs
@@ -7,143 +7,134 @@ namespace OwaspHeaders.Core;
 /// A middleware for injecting OWASP recommended headers into a
 /// HTTP Request
 /// </summary>
-public class SecureHeadersMiddleware()
+public class SecureHeadersMiddleware(RequestDelegate next, SecureHeadersMiddlewareConfiguration config)
 {
-private string _calculatedContentSecurityPolicy;
-private readonly Dictionary<string, string> _headers;
-private readonly RequestDelegate _next;
-private readonly SecureHeadersMiddlewareConfiguration _config;
+    private string _calculatedContentSecurityPolicy;
+    private readonly Dictionary<string, string> _headers = new();
 
-public SecureHeadersMiddleware(RequestDelegate next, SecureHeadersMiddlewareConfiguration config) : this()
-{
-    _config = config;
-    _next = next;
-    _headers = new Dictionary<string, string>();
-}
-
-/// <summary>
-/// The main task of the middleware. This will be invoked whenever
-/// the middleware fires
-/// </summary>
-/// <param name="httpContext">The <see cref="HttpContext" /> for the current request or response</param>
-/// <returns></returns>
-public async Task InvokeAsync(HttpContext httpContext)
-{
-    if (_config == null)
+    /// <summary>
+    /// The main task of the middleware. This will be invoked whenever
+    /// the middleware fires
+    /// </summary>
+    /// <param name="httpContext">The <see cref="HttpContext" /> for the current request or response</param>
+    /// <returns></returns>
+    public async Task InvokeAsync(HttpContext httpContext)
     {
-        throw new ArgumentException(
-            $"Expected an instance of the {nameof(SecureHeadersMiddlewareConfiguration)} object.");
-    }
-
-    if (!RequestShouldBeIgnored(httpContext.Request.Path))
-    {
-        if (_headers.Count == 0)
+        if (config == null)
         {
-            GenerateRelevantHeaders();
+            throw new ArgumentException(
+                $"Expected an instance of the {nameof(SecureHeadersMiddlewareConfiguration)} object.");
         }
 
-        foreach (var (key, value) in _headers)
+        if (!RequestShouldBeIgnored(httpContext.Request.Path))
         {
-            httpContext.TryAddHeader(key, value);
+            if (_headers.Count == 0)
+            {
+                GenerateRelevantHeaders();
+            }
+
+            foreach (var (key, value) in _headers)
+            {
+                httpContext.TryAddHeader(key, value);
+            }
+        }
+
+        // Call the next middleware in the chain
+        await next(httpContext);
+    }
+
+    private void GenerateRelevantHeaders()
+    {
+        if (config.UseHsts)
+        {
+            _headers.TryAdd(Constants.StrictTransportSecurityHeaderName,
+                config.HstsConfiguration.BuildHeaderValue());
+        }
+
+        if (config.UseXFrameOptions)
+        {
+            _headers.TryAdd(Constants.XFrameOptionsHeaderName,
+                config.XFrameOptionsConfiguration.BuildHeaderValue());
+        }
+
+        if (config.UseXssProtection)
+        {
+            _headers.TryAdd(Constants.XssProtectionHeaderName,
+                config.XssConfiguration.BuildHeaderValue());
+        }
+
+        if (config.UseXContentTypeOptions)
+        {
+            _headers.TryAdd(Constants.XContentTypeOptionsHeaderName, Constants.XContentTypeOptionsValue);
+        }
+
+        if (config.UseContentSecurityPolicyReportOnly)
+        {
+            if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
+            {
+                _calculatedContentSecurityPolicy =
+                    config.ContentSecurityPolicyReportOnlyConfiguration.BuildHeaderValue();
+            }
+
+            _headers.TryAdd(Constants.ContentSecurityPolicyReportOnlyHeaderName,
+                _calculatedContentSecurityPolicy);
+        }
+        else if (config.UseContentSecurityPolicy)
+        {
+            if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
+            {
+                _calculatedContentSecurityPolicy = config.ContentSecurityPolicyConfiguration.BuildHeaderValue();
+            }
+
+            _headers.TryAdd(Constants.ContentSecurityPolicyHeaderName,
+                _calculatedContentSecurityPolicy);
+        }
+
+        if (config.UseXContentSecurityPolicy)
+        {
+            _headers.TryAdd(Constants.XContentSecurityPolicyHeaderName,
+                config.ContentSecurityPolicyConfiguration.BuildHeaderValue());
+        }
+
+        if (config.UsePermittedCrossDomainPolicy)
+        {
+            _headers.TryAdd(Constants.PermittedCrossDomainPoliciesHeaderName,
+                config.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
+        }
+
+        if (config.UseReferrerPolicy)
+        {
+            _headers.TryAdd(Constants.ReferrerPolicyHeaderName,
+                config.ReferrerPolicy.BuildHeaderValue());
+        }
+
+        if (config.UseExpectCt)
+        {
+            _headers.TryAdd(Constants.ExpectCtHeaderName,
+                config.ExpectCt.BuildHeaderValue());
+        }
+
+        if (config.UseCacheControl)
+        {
+            _headers.TryAdd(Constants.CacheControlHeaderName,
+                config.CacheControl.BuildHeaderValue());
+        }
+
+        if (config.UseCrossOriginResourcePolicy)
+        {
+            _headers.TryAdd(Constants.CrossOriginResourcePolicyHeaderName,
+                config.CrossOriginResourcePolicy.BuildHeaderValue());
         }
     }
 
-    // Call the next middleware in the chain
-    await _next(httpContext);
-}
-
-private void GenerateRelevantHeaders()
-{
-    if (_config.UseHsts)
+    private bool RequestShouldBeIgnored(PathString requestedPath)
     {
-        _headers.TryAdd(Constants.StrictTransportSecurityHeaderName,
-            _config.HstsConfiguration.BuildHeaderValue());
-    }
-
-    if (_config.UseXFrameOptions)
-    {
-        _headers.TryAdd(Constants.XFrameOptionsHeaderName,
-            _config.XFrameOptionsConfiguration.BuildHeaderValue());
-    }
-
-    if (_config.UseXssProtection)
-    {
-        _headers.TryAdd(Constants.XssProtectionHeaderName,
-            _config.XssConfiguration.BuildHeaderValue());
-    }
-
-    if (_config.UseXContentTypeOptions)
-    {
-        _headers.TryAdd(Constants.XContentTypeOptionsHeaderName, Constants.XContentTypeOptionsValue);
-    }
-
-    if (_config.UseContentSecurityPolicyReportOnly)
-    {
-        if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
+        if (config.UrlsToIgnore.Count == 0)
         {
-            _calculatedContentSecurityPolicy =
-                _config.ContentSecurityPolicyReportOnlyConfiguration.BuildHeaderValue();
+            return false;
         }
 
-        _headers.TryAdd(Constants.ContentSecurityPolicyReportOnlyHeaderName,
-            _calculatedContentSecurityPolicy);
+        return requestedPath.HasValue &&
+               config.UrlsToIgnore.Any(url => url.Equals(requestedPath.Value!, StringComparison.InvariantCulture));
     }
-    else if (_config.UseContentSecurityPolicy)
-    {
-        if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
-        {
-            _calculatedContentSecurityPolicy = _config.ContentSecurityPolicyConfiguration.BuildHeaderValue();
-        }
-
-        _headers.TryAdd(Constants.ContentSecurityPolicyHeaderName,
-            _calculatedContentSecurityPolicy);
-    }
-
-    if (_config.UseXContentSecurityPolicy)
-    {
-        _headers.TryAdd(Constants.XContentSecurityPolicyHeaderName,
-            _config.ContentSecurityPolicyConfiguration.BuildHeaderValue());
-    }
-
-    if (_config.UsePermittedCrossDomainPolicy)
-    {
-        _headers.TryAdd(Constants.PermittedCrossDomainPoliciesHeaderName,
-            _config.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
-    }
-
-    if (_config.UseReferrerPolicy)
-    {
-        _headers.TryAdd(Constants.ReferrerPolicyHeaderName,
-            _config.ReferrerPolicy.BuildHeaderValue());
-    }
-
-    if (_config.UseExpectCt)
-    {
-        _headers.TryAdd(Constants.ExpectCtHeaderName,
-            _config.ExpectCt.BuildHeaderValue());
-    }
-
-    if (_config.UseCacheControl)
-    {
-        _headers.TryAdd(Constants.CacheControlHeaderName,
-            _config.CacheControl.BuildHeaderValue());
-    }
-
-    if (_config.UseCrossOriginResourcePolicy)
-    {
-        _headers.TryAdd(Constants.CrossOriginResourcePolicyHeaderName,
-            _config.CrossOriginResourcePolicy.BuildHeaderValue());
-    }
-}
-
-private bool RequestShouldBeIgnored(PathString requestedPath)
-{
-    if (_config.UrlsToIgnore.Count == 0)
-    {
-        return false;
-    }
-
-    return requestedPath.HasValue &&
-           _config.UrlsToIgnore.Any(url => url.Equals(requestedPath.Value!, StringComparison.InvariantCulture));
-}
 }


### PR DESCRIPTION
## Rationale for this PR

This PR fixes #153 by fixing a _very_ silly mistake. See if you can spot it:

```cs
// problematic line:
public class SecureHeadersMiddleware()

// fixed line:
public class SecureHeadersMiddleware
```

The problematic code was added when following a Rider suggestion to replace the constructor with a Primary constructor. This lead to the inclusion of the parenthesis after the class name, which seems to have had a cascading affect on the way that the .editorconfig saw the file.

There's certainly something in the .editorconfig which is at odds with primary constructors, but that's a problem for another day.

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [:question: ] I have added tests to the OwaspHeaders.Core.Tests project
- [:white_check_mark: ] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [:white_check_mark: ] I have ensured that the code coverage has not dropped below 65%
- [:white_check_mark: ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

#### Optional

- [:question: ] I have documented the new feature in the docs directory
- [:question: ] I have provided a code sample, showing how someone could use the new code

### Any Other Information

This section is optional, but it might be useful to list any other information you think is relevant.
