### PR TITLE
feature/frozen-dictionary

### DIFF
--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>OwaspHeaders.Core</PackageId>
-    <Version>9.6.1</Version>
+    <Version>9.6.2</Version>
     <Authors>Jamie Taylor</Authors>
     <Company>RJJ Software Ltd</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright (c) Jamie Taylor / RJJ Software Ltd</Copyright>
     <PackageTags>owasp http headers security</PackageTags>
-    <Description>An ASP.NET Core Middleware which adds the OWASP recommended HTTP headers for enhanced security.</Description>
+    <Description>An ASP.NET Core Middleware which adds the OWASP recommended HTTP headers, with a single line of code, for enhanced security.</Description>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README-NuGet.md</PackageReadmeFile>
     <PackageProjectUrl>https://gaprogman.github.io/OwaspHeaders.Core/</PackageProjectUrl>

--- a/src/SecureHeadersMiddleware.cs
+++ b/src/SecureHeadersMiddleware.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Frozen;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace OwaspHeaders.Core;
@@ -9,8 +10,7 @@ namespace OwaspHeaders.Core;
 /// </summary>
 public class SecureHeadersMiddleware
 {
-    private string _calculatedContentSecurityPolicy;
-    private readonly Dictionary<string, string> _headers;
+    private FrozenDictionary<string, string> _headers;
     private readonly RequestDelegate _next;
     private readonly SecureHeadersMiddlewareConfiguration _config;
 
@@ -18,7 +18,7 @@ public class SecureHeadersMiddleware
     {
         _config = config;
         _next = next;
-        _headers = new Dictionary<string, string>();
+        _headers = FrozenDictionary<string, string>.Empty;
     }
 
     /// <summary>
@@ -39,7 +39,7 @@ public class SecureHeadersMiddleware
         {
             if (_headers.Count == 0)
             {
-                GenerateRelevantHeaders();
+                _headers = GenerateRelevantHeaders();
             }
 
             foreach (var (key, value) in _headers)
@@ -52,88 +52,81 @@ public class SecureHeadersMiddleware
         await _next(httpContext);
     }
 
-    private void GenerateRelevantHeaders()
+    private FrozenDictionary<string, string> GenerateRelevantHeaders()
     {
+        var temporaryDictionary = new Dictionary<string, string>();
+        
         if (_config.UseHsts)
         {
-            _headers.TryAdd(Constants.StrictTransportSecurityHeaderName,
+            temporaryDictionary.Add(Constants.StrictTransportSecurityHeaderName,
                 _config.HstsConfiguration.BuildHeaderValue());
         }
 
         if (_config.UseXFrameOptions)
         {
-            _headers.TryAdd(Constants.XFrameOptionsHeaderName,
+            temporaryDictionary.Add(Constants.XFrameOptionsHeaderName,
                 _config.XFrameOptionsConfiguration.BuildHeaderValue());
         }
 
         if (_config.UseXssProtection)
         {
-            _headers.TryAdd(Constants.XssProtectionHeaderName,
+            temporaryDictionary.Add(Constants.XssProtectionHeaderName,
                 _config.XssConfiguration.BuildHeaderValue());
         }
 
         if (_config.UseXContentTypeOptions)
         {
-            _headers.TryAdd(Constants.XContentTypeOptionsHeaderName, Constants.XContentTypeOptionsValue);
+            temporaryDictionary.Add(Constants.XContentTypeOptionsHeaderName, Constants.XContentTypeOptionsValue);
         }
 
         if (_config.UseContentSecurityPolicyReportOnly)
         {
-            if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
-            {
-                _calculatedContentSecurityPolicy =
-                    _config.ContentSecurityPolicyReportOnlyConfiguration.BuildHeaderValue();
-            }
-
-            _headers.TryAdd(Constants.ContentSecurityPolicyReportOnlyHeaderName,
-                _calculatedContentSecurityPolicy);
+            temporaryDictionary.Add(Constants.ContentSecurityPolicyReportOnlyHeaderName,
+                _config.ContentSecurityPolicyReportOnlyConfiguration.BuildHeaderValue());
         }
         else if (_config.UseContentSecurityPolicy)
         {
-            if (string.IsNullOrWhiteSpace(_calculatedContentSecurityPolicy))
-            {
-                _calculatedContentSecurityPolicy = _config.ContentSecurityPolicyConfiguration.BuildHeaderValue();
-            }
-
-            _headers.TryAdd(Constants.ContentSecurityPolicyHeaderName,
-                _calculatedContentSecurityPolicy);
+            temporaryDictionary.Add(Constants.ContentSecurityPolicyHeaderName,
+                _config.ContentSecurityPolicyConfiguration.BuildHeaderValue());
         }
 
         if (_config.UseXContentSecurityPolicy)
         {
-            _headers.TryAdd(Constants.XContentSecurityPolicyHeaderName,
+            temporaryDictionary.Add(Constants.XContentSecurityPolicyHeaderName,
                 _config.ContentSecurityPolicyConfiguration.BuildHeaderValue());
         }
 
         if (_config.UsePermittedCrossDomainPolicy)
         {
-            _headers.TryAdd(Constants.PermittedCrossDomainPoliciesHeaderName,
+            temporaryDictionary.Add(Constants.PermittedCrossDomainPoliciesHeaderName,
                 _config.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
         }
 
         if (_config.UseReferrerPolicy)
         {
-            _headers.TryAdd(Constants.ReferrerPolicyHeaderName,
+            temporaryDictionary.Add(Constants.ReferrerPolicyHeaderName,
                 _config.ReferrerPolicy.BuildHeaderValue());
         }
 
         if (_config.UseExpectCt)
         {
-            _headers.TryAdd(Constants.ExpectCtHeaderName,
+            temporaryDictionary.Add(Constants.ExpectCtHeaderName,
                 _config.ExpectCt.BuildHeaderValue());
         }
 
         if (_config.UseCacheControl)
         {
-            _headers.TryAdd(Constants.CacheControlHeaderName,
+            temporaryDictionary.Add(Constants.CacheControlHeaderName,
                 _config.CacheControl.BuildHeaderValue());
         }
 
         if (_config.UseCrossOriginResourcePolicy)
         {
-            _headers.TryAdd(Constants.CrossOriginResourcePolicyHeaderName,
+            temporaryDictionary.Add(Constants.CrossOriginResourcePolicyHeaderName,
                 _config.CrossOriginResourcePolicy.BuildHeaderValue());
         }
+
+        return temporaryDictionary.ToFrozenDictionary();
     }
 
     private bool RequestShouldBeIgnored(PathString requestedPath)

--- a/src/SecureHeadersMiddleware.cs
+++ b/src/SecureHeadersMiddleware.cs
@@ -55,7 +55,7 @@ public class SecureHeadersMiddleware
     private FrozenDictionary<string, string> GenerateRelevantHeaders()
     {
         var temporaryDictionary = new Dictionary<string, string>();
-        
+
         if (_config.UseHsts)
         {
             temporaryDictionary.Add(Constants.StrictTransportSecurityHeaderName,


### PR DESCRIPTION
## Rationale for this PR

This PR enhances execution speed and thread safety by making use of the [FrozenDictionary](https://learn.microsoft.com/en-us/dotnet/api/system.collections.frozen.frozendictionary) class as a cache for the calculated header values.

There is a slight penalty (but not easily perceptible) on first boot of the middleware, but all subsequent requests are now faster than when a standard Dictionary was used.

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [ :question: ] I have added tests to the OwaspHeaders.Core.Tests project
- [ :white_check_mark: ] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [ :white_check_mark: ] I have ensured that the code coverage has not dropped below 65%
- [ :white_check_mark: ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

#### Optional

- [ :question: ] I have documented the new feature in the docs directory
- [ :question: ] I have provided a code sample, showing how someone could use the new code

### Any Other Information

This section is optional, but it might be useful to list any other information you think is relevant.
