### PR TITLE
Bugfix/typos

### DIFF
--- a/src/Models/PermittedCrossDomainPolicyConfiguration.cs
+++ b/src/Models/PermittedCrossDomainPolicyConfiguration.cs
@@ -23,15 +23,15 @@ public class PermittedCrossDomainPolicyConfiguration : IConfigurationBase
         switch (XPermittedCrossDomainOptionValue)
         {
             case XPermittedCrossDomainOptionValue.none:
-                return "none;";
+                return "none";
             case XPermittedCrossDomainOptionValue.masterOnly:
-                return "master-only;";
+                return "master-only";
             case XPermittedCrossDomainOptionValue.byContentType:
-                return "by-content-type;";
+                return "by-content-type";
             case XPermittedCrossDomainOptionValue.byFtpFileType:
-                return "by-ftp-file-type;";
+                return "by-ftp-file-type";
             case XPermittedCrossDomainOptionValue.all:
-                return "all;";
+                return "all";
             default:
                 ArgumentExceptionHelper.RaiseException(nameof(XPermittedCrossDomainOptionValue));
                 break;

--- a/src/Models/XFrameOptionsConfiguration.cs
+++ b/src/Models/XFrameOptionsConfiguration.cs
@@ -27,14 +27,14 @@ public class XFrameOptionsConfiguration : IConfigurationBase
         switch (OptionValue)
         {
             case XFrameOptions.Deny:
-                return "DENY";
+                return "deny";
             case XFrameOptions.Sameorigin:
-                return "SAMEORIGIN";
+                return "sameorigin";
             case XFrameOptions.Allowfrom:
                 HeaderValueGuardClauses.StringCannotBeNullOrWhitsSpace(AllowFromDomain, nameof(AllowFromDomain));
-                return $"ALLOW-FROM({AllowFromDomain})";
+                return $"allow-from: ({AllowFromDomain})";
             case XFrameOptions.AllowAll:
-                return "ALLOWALL";
+                return "allowall";
         }
         // We should never hit this return statement. It is included here
         // as the method NEEDs to return something.

--- a/tests/OwaspHeaders.Core.Tests/CustomHeaders/DefaultSecureHeadersIntegrationTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/CustomHeaders/DefaultSecureHeadersIntegrationTests.cs
@@ -27,7 +27,7 @@ public class DefaultSecureHeadersIntegrationTests : SecureHeadersTests
 
         Assert.True(headerPresentConfig.UseXFrameOptions);
         Assert.Contains(context.Response.Headers, h => h.Key == Constants.XFrameOptionsHeaderName);
-        Assert.Equal("DENY", context.Response.Headers[Constants.XFrameOptionsHeaderName]);
+        Assert.Equal("deny", context.Response.Headers[Constants.XFrameOptionsHeaderName]);
 
         Assert.True(headerPresentConfig.UseXssProtection);
         Assert.Contains(context.Response.Headers, h => h.Key == Constants.XssProtectionHeaderName);
@@ -44,7 +44,7 @@ public class DefaultSecureHeadersIntegrationTests : SecureHeadersTests
 
         Assert.True(headerPresentConfig.UsePermittedCrossDomainPolicy);
         Assert.Contains(context.Response.Headers, h => h.Key == Constants.PermittedCrossDomainPoliciesHeaderName);
-        Assert.Equal("none;", context.Response.Headers[Constants.PermittedCrossDomainPoliciesHeaderName]);
+        Assert.Equal("none", context.Response.Headers[Constants.PermittedCrossDomainPoliciesHeaderName]);
 
         Assert.True(headerPresentConfig.UseReferrerPolicy);
         Assert.Contains(context.Response.Headers, h => h.Key == Constants.ReferrerPolicyHeaderName);

--- a/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
@@ -103,7 +103,7 @@ public class SecureHeadersMiddlewareTests
 
         // X-Frame-Options
         Assert.True(middlewareConfiguration.UseXFrameOptions);
-        Assert.Equal("DENY", middlewareConfiguration.XFrameOptionsConfiguration.BuildHeaderValue());
+        Assert.Equal("deny", middlewareConfiguration.XFrameOptionsConfiguration.BuildHeaderValue());
 
         // X-Content-Type-Options
         Assert.True(middlewareConfiguration.UseXContentTypeOptions);
@@ -116,7 +116,7 @@ public class SecureHeadersMiddlewareTests
 
         // X-Permitted-Cross-Domain-Policies
         Assert.True(middlewareConfiguration.UsePermittedCrossDomainPolicy);
-        Assert.Equal("none;", middlewareConfiguration.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
+        Assert.Equal("none", middlewareConfiguration.PermittedCrossDomainPolicyConfiguration.BuildHeaderValue());
 
         // Referrer-Policy
         Assert.True(middlewareConfiguration.UseReferrerPolicy);


### PR DESCRIPTION
## Rationale for this PR

This PR fixes a number of typos in the generated values for both the X-Permitted-Cross-Domains and X-Frame-Options headers.

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [ :question: ] I have added tests to the OwaspHeaders.Core.Tests project
- [ :question: ] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [ :question: ] I have ensured that the code coverage has not dropped below 65%
- [ :question: ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

#### Optional

- [ :question: ] I have documented the new feature in the docs directory
- [ :question: ] I have provided a code sample, showing how someone could use the new code

### Any Other Information

This section is optional, but it might be useful to list any other information you think is relevant.
