### PR TITLE
Feature/cross origin opener policy

### DIFF
--- a/docs/configuration/Cache-Control.md
+++ b/docs/configuration/Cache-Control.md
@@ -1,6 +1,6 @@
 ---
 title: Cache-Control
-nav_order: 7
+nav_order: 8
 parent: Configuration
 layout: page
 ---

--- a/docs/configuration/Cross-Origin-Opener-Policy.md
+++ b/docs/configuration/Cross-Origin-Opener-Policy.md
@@ -1,0 +1,49 @@
+---
+title: Cross-Origin-Opener-Policy
+nav_order: 9
+parent: Configuration
+layout: page
+---
+
+The Mozilla Developer Network describes the Cross-Origin-Opener-Policy (COOP) header like this:
+
+{: .quote }
+> The HTTP Cross-Origin-Opener-Policy (COOP) response header allows a website to control whether a new top-level
+> document, opened using Window.open() or by navigating to a new page, is opened in the same browsing context group
+> (BCG) or in a new browsing context group.
+>
+> source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
+
+A COOP header can be added in one of two ways, either using the default middleware options:
+
+```csharp
+app.UseSecureHeadersMiddleware();
+```
+
+The above adds the COOP header with a `same-origin` value.
+
+Or by creating an instance of the `SecureHeadersMiddlewareBuilder` class using the following code:
+
+```csharp
+var customConfig = SecureHeadersMiddlewareBuilder
+    .CreateBuilder()
+    .UseCrossOriginOpenerPolicy()
+    .Build();
+
+app.UseSecureHeadersMiddleware(customConfig);
+```
+
+The above adds the COOP header with a `same-origin` value.
+
+## Full Options
+
+The COOP header object (known internally as `CrossOriginOpenerPolicy`) has the following options:
+
+- enum: `CrossOriginOpenerOptions`
+
+The values available for the `CrossOriginOpenerOptions` enum are:
+
+- `CrossOrigin`
+- `SameSite`
+- `SameOrigin`
+

--- a/docs/configuration/Cross-Origin-Resource-Policy.md
+++ b/docs/configuration/Cross-Origin-Resource-Policy.md
@@ -1,0 +1,47 @@
+---
+title: Cross-Origin-Resource-Policy
+nav_order: 7
+parent: Configuration
+layout: page
+---
+
+The Mozilla Developer Network describes the Cross-Origin-Resource-Policy (CORP) header like this:
+
+{: .quote }
+> The HTTP Cross-Origin-Resource-Policy response header indicates that the browser should block no-cors cross-origin or cross-site requests to the given resource.
+>
+> source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy
+
+A CORP header can be added in one of two ways, either using the default middleware options:
+
+```csharp
+app.UseSecureHeadersMiddleware();
+```
+
+The above adds the CORP header with a `same-origin` value.
+
+Or by creating an instance of the `SecureHeadersMiddlewareBuilder` class using the following code:
+
+```csharp
+var customConfig = SecureHeadersMiddlewareBuilder
+    .CreateBuilder()
+    .UseCrossOriginResourcePolicy()
+    .Build();
+
+app.UseSecureHeadersMiddleware(customConfig);
+```
+
+The above adds the CORP header with a `same-origin` value.
+
+## Full Options
+
+The CORP header object (known internally as `CrossOriginResourcePolicy`) has the following options:
+
+- enum: `CrossOriginResourceOptions`
+
+The values available for the `CrossOriginResourceOptions` enum are:
+
+- `CrossOrigin`
+- `SameSite`
+- `SameOrigin`
+

--- a/docs/configuration/X-XSS-Protection.md
+++ b/docs/configuration/X-XSS-Protection.md
@@ -5,14 +5,15 @@ parent: Configuration
 layout: page
 ---
 
+{: .warning }
+Both the OWASP Secure Headers Project and MDN recommend not using this header with any value other than "0", which disabled the XSS Auditor. This is due to the X-XSS-Protection header having been dropped from most modern browsers and that using it (with a value other than "0") can cause additional security issues to present themselves. The recommended path forward is to use a [Content-Security-Policy (CSP)](Content-Security-Policy.md) header.
+
 The Mozilla Developer Network describes the X-XSS-Protection header like this:
 
 {: .quote }
 > The HTTP X-XSS-Protection response header was a feature of Internet Explorer, Chrome and Safari that stopped pages from loading when they detected reflected cross-site scripting (XSS) attacks. These protections are largely unnecessary in modern browsers when sites implement a strong Content-Security-Policy that disables the use of inline JavaScript ('unsafe-inline').
 >
 > source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
-
-Both the OWASP Secure Headers Project and MDN recommend not using this header with any value other than "0", which disabled the XSS Auditor. This is due to the X-XSS-Protection header having been dropped from most modern browsers and that using it (with a value other than "0") can cause additional security issues to present themselves. The recommended path forward is to use a [Content-Security-Policy (CSP)](Content-Security-Policy.md) header.
 
 As such, the only value that OwaspHeaders.Core supports for the X-XSS-Protection header is "0", and the header can be added in one of two ways:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ The following list displays the status of all the current (as of Dec 27th, 2024)
 - [ ✅ ] Cross-Origin-Resource-Policy 
 - [ ✅ ] Cache-Control
 - [ ❌ ] Clear-Site-Data
-- [ ❌ ] Cross-Origin-Opener-Policy
+- [ ✅ ] Cross-Origin-Opener-Policy
 - [ ❌ ] Cross-Origin-Embedder-Policy
 - [ ❌ ] Permissions-Policy
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -84,10 +84,10 @@ The following list displays the status of all the current (as of Dec 27th, 2024)
 - [ ✅ ] Content-Security-Policy
 - [ ✅ ] [X-Permitted-Cross-Domain-Policies] 
 - [ ✅ ] [Referrer-Policy]
-- [ ✅ ] Cross-Origin-Resource-Policy 
+- [ ✅ ] [Cross-Origin-Resource-Policy]
 - [ ✅ ] [Cache-Control]
 - [ ❌ ] Clear-Site-Data
-- [ ✅ ] Cross-Origin-Opener-Policy
+- [ ✅ ] [Cross-Origin-Opener-Policy]
 - [ ❌ ] Cross-Origin-Embedder-Policy
 - [ ❌ ] Permissions-Policy
 
@@ -131,4 +131,6 @@ The `web.config` file will need to be copied to the server when the application 
 [X-Content-Type-Options]: ./configuration/X-Content-Type-Options/
 [X-Permitted-Cross-Domain-Policies]: ./configuration/X-Permitted-Cross-Domain-Policies/
 [Referrer-Policy]: ./configuration/Referrer-Policy/
+[Cross-Origin-Resource-Policy]: ./configuration/Cross-Origin-Resource-Policy/
 [Cache-Control]: ./configuration/Cache-Control/
+[Cross-Origin-Opener-Policy]: ./configuration/Cross-Origin-Opener-Policy/

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,14 +78,14 @@ This project is a work-in-progress, and headers will be added inline with Owasp 
 
 The following list displays the status of all the current (as of Dec 27th, 2024) recommended headers:
 
-- [ ✅ ] Strict-Transport-Security 
-- [ ✅ ] X-Frame-Options
-- [ ✅ ] X-Content-Type-Options
+- [ ✅ ] [Strict-Transport-Security] 
+- [ ✅ ] [X-Frame-Options]
+- [ ✅ ] [X-Content-Type-Options]
 - [ ✅ ] Content-Security-Policy
-- [ ✅ ] X-Permitted-Cross-Domain-Policies 
-- [ ✅ ] Referrer-Policy
+- [ ✅ ] [X-Permitted-Cross-Domain-Policies] 
+- [ ✅ ] [Referrer-Policy]
 - [ ✅ ] Cross-Origin-Resource-Policy 
-- [ ✅ ] Cache-Control
+- [ ✅ ] [Cache-Control]
 - [ ❌ ] Clear-Site-Data
 - [ ✅ ] Cross-Origin-Opener-Policy
 - [ ❌ ] Cross-Origin-Embedder-Policy
@@ -126,3 +126,9 @@ The `web.config` file will need to be copied to the server when the application 
 [Configuration]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/
 [this answer on ServerFault]: https://serverfault.com/a/1020784
 [OWASP Secure Headers List]: https://owasp.org/www-project-secure-headers/#div-headers
+[Strict-Transport-Security]: ./configuration/Strict-Transport-Security/
+[X-Frame-Options]: ./configuration/X-Frame-Options/
+[X-Content-Type-Options]: ./configuration/X-Content-Type-Options/
+[X-Permitted-Cross-Domain-Policies]: ./configuration/X-Permitted-Cross-Domain-Policies/
+[Referrer-Policy]: ./configuration/Referrer-Policy/
+[Cache-Control]: ./configuration/Cache-Control/

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -26,4 +26,5 @@ public static class Constants
     public const string ExpectCtHeaderName = "Expect-CT";
 
     public const string CrossOriginResourcePolicyHeaderName = "Cross-Origin-Resource-Policy";
+    public const string CrossOriginOpenerPolicyHeaderName = "Cross-Origin-Opener-Policy";
 }

--- a/src/Extensions/SecureHeadersMiddlewareBuilder.cs
+++ b/src/Extensions/SecureHeadersMiddlewareBuilder.cs
@@ -318,6 +318,29 @@ public static class SecureHeadersMiddlewareBuilder
     }
 
     /// <summary>
+    /// The HTTP Cross-Origin-Opener-Policy (COOP) response header allows a website to control
+    /// whether a new top-level document, opened using Window.open() or by navigating to a new
+    /// page, is opened in the same browsing context group (BCG) or in a new browsing context group.
+    /// Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
+    /// </summary>
+    /// <param name="value">
+    /// The HTTP Cross-Origin-Opener-Policy response header value.
+    /// </param>
+    /// <remarks>
+    /// Defaults to "same-origin" (<see cref="CrossOriginOpenerPolicy.CrossOriginOpenerOptions.SameOrigin"/>)
+    /// which means that "Only requests from the same Origin (i.e. scheme + host + port) can read the resource."
+    ///</remarks>
+    public static SecureHeadersMiddlewareConfiguration UseCrossOriginOpenerPolicy(
+        this SecureHeadersMiddlewareConfiguration config,
+        CrossOriginOpenerPolicy.CrossOriginOpenerOptions value =
+            CrossOriginOpenerPolicy.CrossOriginOpenerOptions.SameOrigin)
+    {
+        config.UseCrossOriginOpenerPolicy = true;
+        config.CrossOriginOpenerPolicy = new CrossOriginOpenerPolicy(value);
+        return config;
+    }
+
+    /// <summary>
     /// Used to set a list of URLs that the we want the middleware to NOT operate on
     /// </summary>
     /// <param name="config"></param>

--- a/src/Extensions/SecureHeadersMiddlewareExtensions.cs
+++ b/src/Extensions/SecureHeadersMiddlewareExtensions.cs
@@ -33,6 +33,7 @@ public static class SecureHeadersMiddlewareExtensions
             .UseCacheControl()
             .UseXssProtection()
             .UseCrossOriginResourcePolicy()
+            .UseCrossOriginOpenerPolicy()
             .SetUrlsToIgnore(urlIgnoreList)
             .Build();
     }

--- a/src/Models/CrossOriginOpenerPolicy.cs
+++ b/src/Models/CrossOriginOpenerPolicy.cs
@@ -1,0 +1,88 @@
+﻿namespace OwaspHeaders.Core.Models;
+
+/// <summary>
+/// Cross-Origin-Opener-Policy.
+/// The following text was taken from the OWASP Secure Headers Project:
+/// This response header (also named COOP) allows you to ensure a top-level
+/// document does not share a browsing context group with cross-origin documents.
+/// COOP will process-isolate your document and potential attackers can’t access
+/// to your global object if they were opening it in a popup, preventing a
+/// set of cross-origin attacks dubbed XS-Leaks (https://xsleaks.dev/)
+/// (source Mozilla MDN (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)).
+
+
+/// </summary>
+public class CrossOriginOpenerPolicy : IConfigurationBase
+{
+    /// <summary>
+    /// Cross-Origin-Opener-Policy.
+    /// The following text was taken from the OWASP Secure Headers Project:
+    /// This response header (also named COOP) allows you to ensure a top-level
+    /// document does not share a browsing context group with cross-origin documents.
+    /// COOP will process-isolate your document and potential attackers can’t access
+    /// to your global object if they were opening it in a popup, preventing a
+    /// set of cross-origin attacks dubbed XS-Leaks (https://xsleaks.dev/)
+    /// (source Mozilla MDN (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy)).
+    /// </summary>
+    public CrossOriginOpenerPolicy(CrossOriginOpenerOptions value =
+        CrossOriginOpenerOptions.SameOrigin)
+    {
+        OptionValue = value;
+    }
+
+    /// <summary>
+    /// Allows the document to be added to its opener’s browsing context group
+    /// unless the opener itself has a COOP of same-origin or same-origin-allow-popups (it is the default value).
+    /// </summary>
+    private const string UnsafeNoneValue = "unsafe-none";
+
+    /// <summary>
+    /// Only requests from the same Site can read the resource.
+    /// </summary>
+    private const string SameOriginAllowPopupsValue = "same-origin-allow-popups";
+
+    /// <summary>
+    /// Retains references to newly opened windows or tabs which either
+    /// don’t set COOP or which opt out of isolation by setting a COOP
+    /// of unsafe-none
+    /// </summary>
+    public const string SameOriginValue = "same-origin";
+
+    public enum CrossOriginOpenerOptions
+    {
+        /// <summary>
+        /// <see cref="UnsafeNoneValue"/>
+        /// </summary>
+        UnsafeNone,
+
+        /// <summary>
+        /// <see cref="SameOriginAllowPopupsValue"/>
+        /// </summary>
+        SameOriginAllowPopups,
+
+        /// <summary>
+        /// <see cref="SameOriginValue"/>
+        /// </summary>
+        SameOrigin
+    };
+
+    private CrossOriginOpenerOptions OptionValue { get; }
+
+    /// <summary>
+    /// Builds the HTTP header value
+    /// </summary>
+    /// <returns>A string representing the HTTP header value</returns>
+    public string BuildHeaderValue()
+    {
+        switch (OptionValue)
+        {
+            case CrossOriginOpenerOptions.SameOriginAllowPopups:
+                return SameOriginAllowPopupsValue;
+            case CrossOriginOpenerOptions.UnsafeNone:
+                return UnsafeNoneValue;
+            case CrossOriginOpenerOptions.SameOrigin:
+            default:
+                return SameOriginValue;       
+        }
+    }
+}

--- a/src/Models/CrossOriginOpenerPolicy.cs
+++ b/src/Models/CrossOriginOpenerPolicy.cs
@@ -82,7 +82,7 @@ public class CrossOriginOpenerPolicy : IConfigurationBase
                 return UnsafeNoneValue;
             case CrossOriginOpenerOptions.SameOrigin:
             default:
-                return SameOriginValue;       
+                return SameOriginValue;
         }
     }
 }

--- a/src/Models/CrossOriginResourcePolicy.cs
+++ b/src/Models/CrossOriginResourcePolicy.cs
@@ -8,59 +8,73 @@
 /// img tags), to mitigate speculative side-channel attacks, like Spectre, as
 /// well as Cross-Site Script Inclusion(XSSI) attacks(source Mozilla MDN).
 /// </summary>
-public class CrossOriginResourcePolicy(
-    CrossOriginResourcePolicy.CrossOriginResourceOptions value =
-        CrossOriginResourcePolicy.CrossOriginResourceOptions.SameOrigin)
-    : IConfigurationBase
+public class CrossOriginResourcePolicy : IConfigurationBase
 {
+    /// <summary>
+    /// Cross-Origin-Resource-Policy
+    /// This response header(also named CORP) allows to define a policy that let
+    /// websites and applications opt in to protection against certain requests
+    /// from other origins(such as those issued with elements like the script and
+    /// img tags), to mitigate speculative side-channel attacks, like Spectre, as
+    /// well as Cross-Site Script Inclusion(XSSI) attacks(source Mozilla MDN).
+    /// </summary>
+    public CrossOriginResourcePolicy(CrossOriginResourceOptions value =
+        CrossOriginResourceOptions.SameOrigin)
+    {
+        OptionValue = value;
+    }
+
     /// <summary>
     /// Only requests from the same Origin (i.e. scheme + host + port) can read the resource.
     /// </summary>
     public const string SameOriginValue = "same-origin";
-/// <summary>
-/// Only requests from the same Site can read the resource.
-/// </summary>
-public const string SameSiteValue = "same-site";
-/// <summary>
-/// Requests from any Origin (both same-site and cross-site) can read the resource. 
-/// Browsers are using this policy when an CORP header is not specified.
-/// </summary>
-public const string CrossOriginValue = "cross-origin";
 
-public enum CrossOriginResourceOptions
-{
     /// <summary>
-    /// <see cref="SameOriginValue"/>
+    /// Only requests from the same Site can read the resource.
     /// </summary>
-    SameOrigin,
-    /// <summary>
-    /// <see cref="SameSiteValue"/>
-    /// </summary>
-    SameSite,
-    /// <summary>
-    /// <see cref="CrossOriginValue"/>
-    /// </summary>
-    CrossOrigin
-};
+    private const string SameSiteValue = "same-site";
 
-private CrossOriginResourceOptions OptionValue { get; } = value;
+    /// <summary>
+    /// Requests from any Origin (both same-site and cross-site) can read the resource. 
+    /// Browsers are using this policy when an CORP header is not specified.
+    /// </summary>
+    private const string CrossOriginValue = "cross-origin";
 
-/// <summary>
-/// Builds the HTTP header value
-/// </summary>
-/// <returns>A string representing the HTTP header value</returns>
-public string BuildHeaderValue()
-{
-    switch (OptionValue)
+    public enum CrossOriginResourceOptions
     {
-        case CrossOriginResourceOptions.CrossOrigin:
-            return CrossOriginValue;
-        case CrossOriginResourceOptions.SameSite:
-            return SameSiteValue;
-        case CrossOriginResourceOptions.SameOrigin:
-        default:
-            return SameOriginValue;
-    }
-}
+        /// <summary>
+        /// <see cref="SameOriginValue"/>
+        /// </summary>
+        SameOrigin,
 
+        /// <summary>
+        /// <see cref="SameSiteValue"/>
+        /// </summary>
+        SameSite,
+
+        /// <summary>
+        /// <see cref="CrossOriginValue"/>
+        /// </summary>
+        CrossOrigin
+    };
+
+    private CrossOriginResourceOptions OptionValue { get; }
+
+    /// <summary>
+    /// Builds the HTTP header value
+    /// </summary>
+    /// <returns>A string representing the HTTP header value</returns>
+    public string BuildHeaderValue()
+    {
+        switch (OptionValue)
+        {
+            case CrossOriginResourceOptions.CrossOrigin:
+                return CrossOriginValue;
+            case CrossOriginResourceOptions.SameSite:
+                return SameSiteValue;
+            case CrossOriginResourceOptions.SameOrigin:
+            default:
+                return SameOriginValue;
+        }
+    }
 }

--- a/src/Models/SecureHeadersMiddlewareConfiguration.cs
+++ b/src/Models/SecureHeadersMiddlewareConfiguration.cs
@@ -66,7 +66,7 @@ public class SecureHeadersMiddlewareConfiguration
     /// Indicates whether the response should use Cross-Origin-Resource-Policy
     /// </summary>
     public bool UseCrossOriginResourcePolicy { get; set; }
-    
+
     /// <summary>
     /// Indicates whether the response should use Cross-Origin-Opener-Policy
     /// </summary>
@@ -118,7 +118,7 @@ public class SecureHeadersMiddlewareConfiguration
     public ExpectCt ExpectCt { get; set; }
 
     public CrossOriginResourcePolicy CrossOriginResourcePolicy { get; set; }
-    
+
     public CrossOriginOpenerPolicy CrossOriginOpenerPolicy { get; set; }
 
     /// <summary>

--- a/src/Models/SecureHeadersMiddlewareConfiguration.cs
+++ b/src/Models/SecureHeadersMiddlewareConfiguration.cs
@@ -66,6 +66,11 @@ public class SecureHeadersMiddlewareConfiguration
     /// Indicates whether the response should use Cross-Origin-Resource-Policy
     /// </summary>
     public bool UseCrossOriginResourcePolicy { get; set; }
+    
+    /// <summary>
+    /// Indicates whether the response should use Cross-Origin-Opener-Policy
+    /// </summary>
+    public bool UseCrossOriginOpenerPolicy { get; set; }
 
     /// <summary>
     /// The HTTP Strict Transport Security configuration to use
@@ -113,6 +118,8 @@ public class SecureHeadersMiddlewareConfiguration
     public ExpectCt ExpectCt { get; set; }
 
     public CrossOriginResourcePolicy CrossOriginResourcePolicy { get; set; }
+    
+    public CrossOriginOpenerPolicy CrossOriginOpenerPolicy { get; set; }
 
     /// <summary>
     /// A list of URLs that, when requested, should be ignored completely by

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>OwaspHeaders.Core</PackageId>
-    <Version>9.6.2</Version>
+    <Version>9.7.0</Version>
     <Authors>Jamie Taylor</Authors>
     <Company>RJJ Software Ltd</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/SecureHeadersMiddleware.cs
+++ b/src/SecureHeadersMiddleware.cs
@@ -126,6 +126,12 @@ public class SecureHeadersMiddleware
                 _config.CrossOriginResourcePolicy.BuildHeaderValue());
         }
 
+        if (_config.UseCrossOriginOpenerPolicy)
+        {
+            temporaryDictionary.Add(Constants.CrossOriginOpenerPolicyHeaderName,
+                _config.CrossOriginOpenerPolicy.BuildHeaderValue());
+        }
+
         return temporaryDictionary.ToFrozenDictionary();
     }
 

--- a/tests/OwaspHeaders.Core.Tests/CustomHeaders/CrossOriginOptionsTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/CustomHeaders/CrossOriginOptionsTests.cs
@@ -20,7 +20,7 @@ public class CrossOriginOptionsTests : SecureHeadersTests
         Assert.Equal(CrossOriginResourcePolicy.SameOriginValue,
             _context.Response.Headers[Constants.CrossOriginResourcePolicyHeaderName]);
     }
-    
+
     [Fact]
     public async Task When_UseCrossOriginOpenerPolicyCalled_Header_Is_Present()
     {
@@ -55,7 +55,7 @@ public class CrossOriginOptionsTests : SecureHeadersTests
         Assert.False(headerNotPresentConfig.UseCrossOriginResourcePolicy);
         Assert.False(_context.Response.Headers.ContainsKey(Constants.CrossOriginResourcePolicyHeaderName));
     }
-    
+
     [Fact]
     public async Task When_UseCrossOriginOpenerPolicyNotCalled_Header_Not_Present()
     {

--- a/tests/OwaspHeaders.Core.Tests/CustomHeaders/CrossOriginOptionsTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/CustomHeaders/CrossOriginOptionsTests.cs
@@ -20,6 +20,25 @@ public class CrossOriginOptionsTests : SecureHeadersTests
         Assert.Equal(CrossOriginResourcePolicy.SameOriginValue,
             _context.Response.Headers[Constants.CrossOriginResourcePolicyHeaderName]);
     }
+    
+    [Fact]
+    public async Task When_UseCrossOriginOpenerPolicyCalled_Header_Is_Present()
+    {
+        // arrange
+        var headerPresentConfig =
+            SecureHeadersMiddlewareBuilder.CreateBuilder()
+                .UseCrossOriginOpenerPolicy().Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.True(headerPresentConfig.UseCrossOriginOpenerPolicy);
+        Assert.True(_context.Response.Headers.ContainsKey(Constants.CrossOriginOpenerPolicyHeaderName));
+        Assert.Equal(CrossOriginOpenerPolicy.SameOriginValue,
+            _context.Response.Headers[Constants.CrossOriginOpenerPolicyHeaderName]);
+    }
 
     [Fact]
     public async Task When_UseCrossOriginResourcePolicyNotCalled_Header_Not_Present()
@@ -36,4 +55,21 @@ public class CrossOriginOptionsTests : SecureHeadersTests
         Assert.False(headerNotPresentConfig.UseCrossOriginResourcePolicy);
         Assert.False(_context.Response.Headers.ContainsKey(Constants.CrossOriginResourcePolicyHeaderName));
     }
+    
+    [Fact]
+    public async Task When_UseCrossOriginOpenerPolicyNotCalled_Header_Not_Present()
+    {
+        // arrange
+        var headerNotPresentConfig = SecureHeadersMiddlewareBuilder.CreateBuilder()
+            .Build();
+        var secureHeadersMiddleware = new SecureHeadersMiddleware(_onNext, headerNotPresentConfig);
+
+        // act
+        await secureHeadersMiddleware.InvokeAsync(_context);
+
+        // assert
+        Assert.False(headerNotPresentConfig.UseCrossOriginOpenerPolicy);
+        Assert.False(_context.Response.Headers.ContainsKey(Constants.CrossOriginOpenerPolicyHeaderName));
+    }
 }
+

--- a/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
@@ -133,5 +133,9 @@ public class SecureHeadersMiddlewareTests
         // Cross-Origin Resource Policy
         Assert.True(middlewareConfiguration.UseCrossOriginResourcePolicy);
         Assert.Equal("same-origin", middlewareConfiguration.CrossOriginResourcePolicy.BuildHeaderValue());
+        
+        // Cross-Origin Opener Policy
+        Assert.True(middlewareConfiguration.UseCrossOriginOpenerPolicy);
+        Assert.Equal("same-origin", middlewareConfiguration.CrossOriginOpenerPolicy.BuildHeaderValue());
     }
 }

--- a/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/SecureHeadersMiddlewareExtensionTests/SecureHeadersMiddlewareTests.cs
@@ -133,7 +133,7 @@ public class SecureHeadersMiddlewareTests
         // Cross-Origin Resource Policy
         Assert.True(middlewareConfiguration.UseCrossOriginResourcePolicy);
         Assert.Equal("same-origin", middlewareConfiguration.CrossOriginResourcePolicy.BuildHeaderValue());
-        
+
         // Cross-Origin Opener Policy
         Assert.True(middlewareConfiguration.UseCrossOriginOpenerPolicy);
         Assert.Equal("same-origin", middlewareConfiguration.CrossOriginOpenerPolicy.BuildHeaderValue());


### PR DESCRIPTION
## Rationale for this PR

This PR adds the following header: Cross-Origin-Opener-Policy. This recommended value header is documented [here](https://owasp.org/www-project-secure-headers/#cross-origin-opener-policy), and the header itself is documented [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy).

This PR closes #75 

The following is a [minimal code sample](https://gaprogman.github.io/OwaspHeaders.Core/Minimal-Code-Sample/) for the new feature:

```csharp
// in Program.cs
app.UseSecureHeadersMiddleware();
```

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [ :white_check_mark: ] I have added tests to the OwaspHeaders.Core.Tests project
- [ :white_check_mark: ] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [ :white_check_mark: ] I have ensured that the code coverage has not dropped below 65%
- [ :white_check_mark: ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

#### Optional

- [ :negative_squared_cross_mark: ] I have documented the new feature in the docs directory
- [ :negative_squared_cross_mark: ] I have provided a code sample, showing how someone could use the new code

### Any Other Information

This section is optional, but it might be useful to list any other information you think is relevant.
