### PR TITLE
Bugfix/docs links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -78,16 +78,16 @@ This project is a work-in-progress, and headers will be added inline with Owasp 
 
 The following list displays the status of all the current (as of Dec 27th, 2024) recommended headers:
 
-- [ ✅ ] [Strict-Transport-Security] 
-- [ ✅ ] [X-Frame-Options]
-- [ ✅ ] [X-Content-Type-Options]
+- [ ✅ ] [Strict-Transport-Security](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Strict-Transport-Security/)
+- [ ✅ ] [X-Frame-Options](https://gaprogman.github.io/OwaspHeaders.Core/configuration/X-Frame-Options/)
+- [ ✅ ] [X-Content-Type-Options](https://gaprogman.github.io/OwaspHeaders.Core/configuration/X-Content-Type-Options/)
 - [ ✅ ] Content-Security-Policy
-- [ ✅ ] [X-Permitted-Cross-Domain-Policies] 
-- [ ✅ ] [Referrer-Policy]
-- [ ✅ ] [Cross-Origin-Resource-Policy]
-- [ ✅ ] [Cache-Control]
+- [ ✅ ] [X-Permitted-Cross-Domain-Policies](https://gaprogman.github.io/OwaspHeaders.Core/configuration/X-Permitted-Cross-Domain-Policies/)
+- [ ✅ ] [Referrer-Policy](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Referrer-Policy/)
+- [ ✅ ] [Cross-Origin-Resource-Policy](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Resource-Policy/)
+- [ ✅ ] [Cache-Control](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cache-Control/)
 - [ ❌ ] Clear-Site-Data
-- [ ✅ ] [Cross-Origin-Opener-Policy]
+- [ ✅ ] [Cross-Origin-Opener-Policy](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Opener-Policy/)
 - [ ❌ ] Cross-Origin-Embedder-Policy
 - [ ❌ ] Permissions-Policy
 
@@ -126,11 +126,3 @@ The `web.config` file will need to be copied to the server when the application 
 [Configuration]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/
 [this answer on ServerFault]: https://serverfault.com/a/1020784
 [OWASP Secure Headers List]: https://owasp.org/www-project-secure-headers/#div-headers
-[Strict-Transport-Security]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/Strict-Transport-Security/
-[X-Frame-Options]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/X-Frame-Options/
-[X-Content-Type-Options]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/X-Content-Type-Options/
-[X-Permitted-Cross-Domain-Policies]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/X-Permitted-Cross-Domain-Policies/
-[Referrer-Policy]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/Referrer-Policy/
-[Cross-Origin-Resource-Policy]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Resource-Policy/
-[Cache-Control]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cache-Control/
-[Cross-Origin-Opener-Policy]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Opener-Policy/

--- a/docs/index.md
+++ b/docs/index.md
@@ -126,11 +126,11 @@ The `web.config` file will need to be copied to the server when the application 
 [Configuration]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/
 [this answer on ServerFault]: https://serverfault.com/a/1020784
 [OWASP Secure Headers List]: https://owasp.org/www-project-secure-headers/#div-headers
-[Strict-Transport-Security]: ./configuration/Strict-Transport-Security/
-[X-Frame-Options]: ./configuration/X-Frame-Options/
-[X-Content-Type-Options]: ./configuration/X-Content-Type-Options/
-[X-Permitted-Cross-Domain-Policies]: ./configuration/X-Permitted-Cross-Domain-Policies/
-[Referrer-Policy]: ./configuration/Referrer-Policy/
-[Cross-Origin-Resource-Policy]: ./configuration/Cross-Origin-Resource-Policy/
-[Cache-Control]: ./configuration/Cache-Control/
-[Cross-Origin-Opener-Policy]: ./configuration/Cross-Origin-Opener-Policy/
+[Strict-Transport-Security]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/Strict-Transport-Security/
+[X-Frame-Options]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/X-Frame-Options/
+[X-Content-Type-Options]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/X-Content-Type-Options/
+[X-Permitted-Cross-Domain-Policies]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/X-Permitted-Cross-Domain-Policies/
+[Referrer-Policy]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/Referrer-Policy/
+[Cross-Origin-Resource-Policy]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Resource-Policy/
+[Cache-Control]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cache-Control/
+[Cross-Origin-Opener-Policy]: https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Opener-Policy/


### PR DESCRIPTION
## Rationale for this PR

This PR fixes an issue where all of the internal links to header docs pages are missing from the index page. See the following screenshot for the issue:

![image](https://github.com/user-attachments/assets/0bea4d8f-2791-44cd-8a2b-bed8d9ec0fdd)

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [ :white_check_mark: ] I have added tests to the OwaspHeaders.Core.Tests project
- [ :white_check_mark: ] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [ :white_check_mark: ] I have ensured that the code coverage has not dropped below 65%
- [ :white_check_mark: ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

#### Optional

- [ :negative_squared_cross_mark: ] I have documented the new feature in the docs directory
- [ :negative_squared_cross_mark: ] I have provided a code sample, showing how someone could use the new code

### Any Other Information

This section is optional, but it might be useful to list any other information you think is relevant.
