### PR TITLE
Fix readme: Http header syntax highlighting

### DIFF
--- a/README-NuGet.md
+++ b/README-NuGet.md
@@ -30,16 +30,16 @@ This will add a number of default HTTP headers to all responses from your server
 
 The following is an example of the response headers from version 9.0.0 (taken on November 19th, 2024)
 
-```plaintext
- cache-control: max-age=31536000,private 
- content-security-policy: script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests; 
- cross-origin-resource-policy: same-origin 
- referrer-policy: no-referrer 
- strict-transport-security: max-age=31536000;includeSubDomains 
- x-content-type-options: nosniff 
- x-frame-options: DENY 
- x-permitted-cross-domain-policies: none; 
- x-xss-protection: 0 
+```http
+cache-control: max-age=31536000,private 
+content-security-policy: script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests; 
+cross-origin-resource-policy: same-origin 
+referrer-policy: no-referrer 
+strict-transport-security: max-age=31536000;includeSubDomains 
+x-content-type-options: nosniff 
+x-frame-options: DENY 
+x-permitted-cross-domain-policies: none; 
+x-xss-protection: 0 
 ```
 
 Please note: The above example contains only the headers added by the Middleware.

--- a/README.md
+++ b/README.md
@@ -54,16 +54,16 @@ This will add a number of default HTTP headers to all responses from your server
 
 The following is an example of the response headers from version 9.0.0 (taken on November 19th, 2024)
 
-```plaintext
- cache-control: max-age=31536000,private 
- content-security-policy: script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests; 
- cross-origin-resource-policy: same-origin 
- referrer-policy: no-referrer 
- strict-transport-security: max-age=31536000;includeSubDomains 
- x-content-type-options: nosniff 
- x-frame-options: DENY 
- x-permitted-cross-domain-policies: none; 
- x-xss-protection: 0 
+```http
+cache-control: max-age=31536000,private 
+content-security-policy: script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests; 
+cross-origin-resource-policy: same-origin 
+referrer-policy: no-referrer 
+strict-transport-security: max-age=31536000;includeSubDomains 
+x-content-type-options: nosniff 
+x-frame-options: DENY 
+x-permitted-cross-domain-policies: none; 
+x-xss-protection: 0 
 ```
 
 Please note: The above example contains only the headers added by the Middleware.


### PR DESCRIPTION
### Rationale for this PR
This PR is a minor semantic fix to readme files of GitHub and NuGet, that adds syntax highlighting for http header code block.

Org (using plaintext):
```plaintext
 cache-control: max-age=31536000,private 
 content-security-policy: script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests; 
 cross-origin-resource-policy: same-origin 
 referrer-policy: no-referrer 
 strict-transport-security: max-age=31536000;includeSubDomains 
 x-content-type-options: nosniff 
 x-frame-options: DENY 
 x-permitted-cross-domain-policies: none; 
 x-xss-protection: 0 
```


Suggested (using http - and removing leading whitespace):
```http
cache-control: max-age=31536000,private 
content-security-policy: script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests; 
cross-origin-resource-policy: same-origin 
referrer-policy: no-referrer 
strict-transport-security: max-age=31536000;includeSubDomains 
x-content-type-options: nosniff 
x-frame-options: DENY 
x-permitted-cross-domain-policies: none; 
x-xss-protection: 0 
```

PR Checklist
Feel free to either check the following items (by place an x inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

:white_check_mark: to indicate that you have checked something off
:negative_squared_cross_mark: to indicate that you haven’t checked something off
:question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

**Essential**
These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

:question: I have added tests to the OwaspHeaders.Core.Tests project
:question: I have run the dotnet-format command and fixed any .editorconfig issues
:question: I have ensured that the code coverage has not dropped below 65%
:question: I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

Optional
:question: I have documented the new feature in the docs directory

### Any Other Information
No other information