### PR TITLE
Feature/cross origin embedder policy

### DIFF
--- a/README-NuGet.md
+++ b/README-NuGet.md
@@ -31,15 +31,17 @@ This will add a number of default HTTP headers to all responses from your server
 The following is an example of the response headers from version 9.0.0 (taken on November 19th, 2024)
 
 ```http
-cache-control: max-age=31536000,private 
-content-security-policy: script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests; 
-cross-origin-resource-policy: same-origin 
-referrer-policy: no-referrer 
-strict-transport-security: max-age=31536000;includeSubDomains 
-x-content-type-options: nosniff 
-x-frame-options: DENY 
-x-permitted-cross-domain-policies: none; 
-x-xss-protection: 0 
+strict-transport-security: max-age=31536000;includesubdomains
+x-frame-options: deny
+x-content-type-options: nosniff
+content-security-policy: script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests;
+x-permitted-cross-domain-policies: none
+referrer-policy: no-referrer
+cross-origin-resource-policy: same-origin
+cache-control: max-age=0,no-store
+cross-origin-opener-policy: same-origin
+cross-origin-embedder-policy: same-require-corp
+x-xss-protection: 0
 ```
 
 Please note: The above example contains only the headers added by the Middleware.

--- a/README.md
+++ b/README.md
@@ -55,15 +55,17 @@ This will add a number of default HTTP headers to all responses from your server
 The following is an example of the response headers from version 9.0.0 (taken on November 19th, 2024)
 
 ```http
-cache-control: max-age=31536000,private 
-content-security-policy: script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests; 
-cross-origin-resource-policy: same-origin 
-referrer-policy: no-referrer 
-strict-transport-security: max-age=31536000;includeSubDomains 
-x-content-type-options: nosniff 
-x-frame-options: DENY 
-x-permitted-cross-domain-policies: none; 
-x-xss-protection: 0 
+strict-transport-security: max-age=31536000;includesubdomains
+x-frame-options: deny
+x-content-type-options: nosniff
+content-security-policy: script-src 'self';object-src 'self';block-all-mixed-content;upgrade-insecure-requests;
+x-permitted-cross-domain-policies: none
+referrer-policy: no-referrer
+cross-origin-resource-policy: same-origin
+cache-control: max-age=0,no-store
+cross-origin-opener-policy: same-origin
+cross-origin-embedder-policy: same-require-corp
+x-xss-protection: 0
 ```
 
 Please note: The above example contains only the headers added by the Middleware.

--- a/changelog.md
+++ b/changelog.md
@@ -4,23 +4,27 @@ This changelog represents all the major (i.e. breaking) changes made to the Owas
 
 ## TL;DR
 
-| Major Version Number | Changes                                                                 |
-|----------------------|-------------------------------------------------------------------------|
-| 9                    | Removed support for both .NET 6 and .NET 7 as these are no longer supported by Microsoft. It also adds support for .NET 9. |
-| 8                    | Removed support for ASP .NET Core on .NET Framework workflows; example and test projects now have OwaspHeaders.Core prefix, re-architected some of the test classes |
-| 7                    | Added Cross-Origin-Resource-Policy header to list of defaults; simplified the use of the middleware in Composite Root/Program.cs |
-| 6                    | Removes Expect-CT Header from the list of default headers |
-| 5                    | XSS Protection is now hard-coded to return "0" if enabled |
-| 4                    | Uses builder pattern to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> uses .NET Standard 2.0 <br /> Removed XSS Protection header from defaults |
-| 3                    | Uses builder pattern to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Standard 2.0 |
-| 2                    | Uses `secureHeaderSettings.json` and default config loader to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Core 2.0 |
-| 1                    | Uses `secureHeaderSettings.json` and default config loader to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Standard 1.4 |
+| Major Version Number | Changes                                                                                                                                                                                                                                                                                                                             |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 9                    | Removed support for both .NET 6 and .NET 7 as these are no longer supported by Microsoft. It also adds support for .NET 9. <br /> A number of small optimisation have been made to the middleware's `Invoke` method <br /> Added support for both Cross-Origin-Opener-Policy (CORP) and Cross-Origin-Embedder-Policy (COEP) headers |
+| 8                    | Removed support for ASP .NET Core on .NET Framework workflows; example and test projects now have OwaspHeaders.Core prefix, re-architected some of the test classes                                                                                                                                                                 |
+| 7                    | Added Cross-Origin-Resource-Policy header to list of defaults; simplified the use of the middleware in Composite Root/Program.cs                                                                                                                                                                                                    |
+| 6                    | Removes Expect-CT Header from the list of default headers                                                                                                                                                                                                                                                                           |
+| 5                    | XSS Protection is now hard-coded to return "0" if enabled                                                                                                                                                                                                                                                                           |
+| 4                    | Uses builder pattern to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> uses .NET Standard 2.0 <br /> Removed XSS Protection header from defaults                                                                                                                                                           |
+| 3                    | Uses builder pattern to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Standard 2.0                                                                                                                                                                                                         |
+| 2                    | Uses `secureHeaderSettings.json` and default config loader to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Core 2.0                                                                                                                                                                       |
+| 1                    | Uses `secureHeaderSettings.json` and default config loader to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Standard 1.4                                                                                                                                                                   |
 
 ### Version 9
 
 This version dropped support for .NET 6 and .NET 7, as they are no longer supported by Microsoft. It also added support for .NET 9.
 
 All projects in the [GitHub repo](https://github.com/GaProgMan/OwaspHeaders.Core) now build and run with either .NET 8 or .NET 9, whichever is present (deferring to the highest version number if both are present). As of November 19th, 2024 there are no new features in Version 9, so if you still need to use the NuGet package with .NET 6 or 7 please use Version 8 of the package.
+
+#### Verison 9.7.x
+
+This version saw the addition of both the [Cross-Origin-Opener-Policy](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Opener-Policy/) (COEP) and [Cross-Origin-Embedder-Policy](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Embedder-Policy/) (COEP) headers; bringing the total number of supported headers to 83% complete (or 10 of the 12 recommended headers and values).
 
 #### Version 9.6.x
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,32 +1,30 @@
----
-title: Changelog
-layout: page
-nav_order: 7
----
-
 # Changelog
 
 This changelog represents all the major (i.e. breaking) changes made to the OwaspHeaders.Core project since it's inception. Early in the repo's development, GitHub's "releases" where used to release builds of the code repo. However shortly after it's inception, builds and releases where moved to [AppVeyor](https://ci.appveyor.com/project/GaProgMan/owaspheaders-core). Because of this, the releases on the GitHub repo became stale.
 
 ## TL;DR
 
-| Major Version Number | Changes                                                                 |
-|----------------------|-------------------------------------------------------------------------|
-| 9                    | Removed support for both .NET 6 and .NET 7 as these are no longer supported by Microsoft. It also adds support for .NET 9. |
-| 8                    | Removed support for ASP .NET Core on .NET Framework workflows; example and test projects now have OwaspHeaders.Core prefix, re-architected some of the test classes |
-| 7                    | Added Cross-Origin-Resource-Policy header to list of defaults; simplified the use of the middleware in Composite Root/Program.cs |
-| 6                    | Removes Expect-CT Header from the list of default headers |
-| 5                    | XSS Protection is now hard-coded to return "0" if enabled |
-| 4                    | Uses builder pattern to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> uses .NET Standard 2.0 <br /> Removed XSS Protection header from defaults |
-| 3                    | Uses builder pattern to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Standard 2.0 |
-| 2                    | Uses `secureHeaderSettings.json` and default config loader to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Core 2.0 |
-| 1                    | Uses `secureHeaderSettings.json` and default config loader to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Standard 1.4 |
+| Major Version Number | Changes                                                                                                                                                                                                                                                                                                                             |
+|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 9                    | Removed support for both .NET 6 and .NET 7 as these are no longer supported by Microsoft. It also adds support for .NET 9. <br /> A number of small optimisation have been made to the middleware's `Invoke` method <br /> Added support for both Cross-Origin-Opener-Policy (CORP) and Cross-Origin-Embedder-Policy (COEP) headers |
+| 8                    | Removed support for ASP .NET Core on .NET Framework workflows; example and test projects now have OwaspHeaders.Core prefix, re-architected some of the test classes                                                                                                                                                                 |
+| 7                    | Added Cross-Origin-Resource-Policy header to list of defaults; simplified the use of the middleware in Composite Root/Program.cs                                                                                                                                                                                                    |
+| 6                    | Removes Expect-CT Header from the list of default headers                                                                                                                                                                                                                                                                           |
+| 5                    | XSS Protection is now hard-coded to return "0" if enabled                                                                                                                                                                                                                                                                           |
+| 4                    | Uses builder pattern to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> uses .NET Standard 2.0 <br /> Removed XSS Protection header from defaults                                                                                                                                                           |
+| 3                    | Uses builder pattern to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Standard 2.0                                                                                                                                                                                                         |
+| 2                    | Uses `secureHeaderSettings.json` and default config loader to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Core 2.0                                                                                                                                                                       |
+| 1                    | Uses `secureHeaderSettings.json` and default config loader to create instances of `SecureHeadersMiddlewareConfiguration` class <br /> also uses .NET Standard 1.4                                                                                                                                                                   |
 
 ### Version 9
 
 This version dropped support for .NET 6 and .NET 7, as they are no longer supported by Microsoft. It also added support for .NET 9.
 
 All projects in the [GitHub repo](https://github.com/GaProgMan/OwaspHeaders.Core) now build and run with either .NET 8 or .NET 9, whichever is present (deferring to the highest version number if both are present). As of November 19th, 2024 there are no new features in Version 9, so if you still need to use the NuGet package with .NET 6 or 7 please use Version 8 of the package.
+
+#### Verison 9.7.x
+
+This version saw the addition of both the [Cross-Origin-Opener-Policy](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Opener-Policy/) (COEP) and [Cross-Origin-Embedder-Policy](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Embedder-Policy/) (COEP) headers; bringing the total number of supported headers to 83% complete (or 10 of the 12 recommended headers and values).
 
 #### Version 9.6.x
 

--- a/docs/configuration/Cross-Origin-Embedder-Policy.md
+++ b/docs/configuration/Cross-Origin-Embedder-Policy.md
@@ -1,0 +1,53 @@
+---
+title: Cross-Origin-Opener-Policy
+nav_order: 10
+parent: Configuration
+layout: page
+---
+
+The Mozilla Developer Network describes the Cross-Origin-Embedder-Policy (COEP) header like this:
+
+{: .quote }
+> The HTTP Cross-Origin-Embedder-Policy (COEP) response header configures embedding cross-origin resources into the document.
+>
+> source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
+
+A COEP header can be added in one of two ways, either using the default middleware options:
+
+```csharp
+app.UseSecureHeadersMiddleware();
+```
+
+The above adds the COEP header with a `require-corp` value.
+
+Or by creating an instance of the `SecureHeadersMiddlewareBuilder` class using the following code:
+
+```csharp
+var customConfig = SecureHeadersMiddlewareBuilder
+    .CreateBuilder()
+    .UseCrossOriginResourcePolicy()
+    .UseCrossOriginEmbedderPolicy()
+    .Build();
+
+app.UseSecureHeadersMiddleware(customConfig);
+```
+
+{: .warning }
+> It is important to note that the recommended value for this header requires the presence of the
+> [Cross-Origin-Resource-Policy (CORP) header](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Resource-Policy/)
+> in order to work.
+> As such, if you add the COEP header without the CORP header, OwaspHeaders.Core will raise an ArgumentException.
+
+The above adds the COEP header with a `require-corp` value.
+
+## Full Options
+
+The COEP header object (known internally as `CrossOriginEmbedderPolicy`) has the following options:
+
+- enum: `CrossOriginEmbedderOptions`
+
+The values available for the `CrossOriginEmbedderOptions` enum are:
+
+- `UnsafeNoneValue`
+- `RequireCorp`
+

--- a/docs/configuration/Cross-Origin-Opener-Policy.md
+++ b/docs/configuration/Cross-Origin-Opener-Policy.md
@@ -43,7 +43,7 @@ The COOP header object (known internally as `CrossOriginOpenerPolicy`) has the f
 
 The values available for the `CrossOriginOpenerOptions` enum are:
 
-- `CrossOrigin`
-- `SameSite`
+- `UnsafeNone`
+- `SameOriginAllowPopups`
 - `SameOrigin`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ The following list displays the status of all the current (as of Dec 27th, 2024)
 - [ ✅ ] [Cache-Control](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cache-Control/)
 - [ ❌ ] Clear-Site-Data
 - [ ✅ ] [Cross-Origin-Opener-Policy](https://gaprogman.github.io/OwaspHeaders.Core/configuration/Cross-Origin-Opener-Policy/)
-- [ ❌ ] Cross-Origin-Embedder-Policy
+- [ ✅ ] Cross-Origin-Embedder-Policy
 - [ ❌ ] Permissions-Policy
 
 Key:

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -26,5 +26,8 @@ public static class Constants
     public const string ExpectCtHeaderName = "Expect-CT";
 
     public const string CrossOriginResourcePolicyHeaderName = "Cross-Origin-Resource-Policy";
+    
     public const string CrossOriginOpenerPolicyHeaderName = "Cross-Origin-Opener-Policy";
+    
+    public const string CrossOriginEmbedderPolicyHeaderName = "Cross-Origin-Embedder-Policy";
 }

--- a/src/Constants.cs
+++ b/src/Constants.cs
@@ -26,8 +26,8 @@ public static class Constants
     public const string ExpectCtHeaderName = "Expect-CT";
 
     public const string CrossOriginResourcePolicyHeaderName = "Cross-Origin-Resource-Policy";
-    
+
     public const string CrossOriginOpenerPolicyHeaderName = "Cross-Origin-Opener-Policy";
-    
+
     public const string CrossOriginEmbedderPolicyHeaderName = "Cross-Origin-Embedder-Policy";
 }

--- a/src/Extensions/SecureHeadersMiddlewareBuilder.cs
+++ b/src/Extensions/SecureHeadersMiddlewareBuilder.cs
@@ -339,7 +339,7 @@ public static class SecureHeadersMiddlewareBuilder
         config.CrossOriginOpenerPolicy = new CrossOriginOpenerPolicy(value);
         return config;
     }
-    
+
     /// <summary>
     /// The HTTP Cross-Origin-Embedder-Policy (COEP) response header configures embedding
     /// cross-origin resources into the document.

--- a/src/Extensions/SecureHeadersMiddlewareBuilder.cs
+++ b/src/Extensions/SecureHeadersMiddlewareBuilder.cs
@@ -339,9 +339,31 @@ public static class SecureHeadersMiddlewareBuilder
         config.CrossOriginOpenerPolicy = new CrossOriginOpenerPolicy(value);
         return config;
     }
+    
+    /// <summary>
+    /// The HTTP Cross-Origin-Embedder-Policy (COEP) response header configures embedding
+    /// cross-origin resources into the document.
+    /// Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy
+    /// </summary>
+    /// <param name="value">
+    /// The HTTP Cross-Origin-Embedder-Policy response header value.
+    /// </param>
+    /// <remarks>
+    /// Defaults to "require-corp" (<see cref="CrossOriginEmbedderPolicy.CrossOriginEmbedderOptions.RequireCorp"/>)
+    /// which means that "Only requests from the same Origin (i.e. scheme + host + port) can read the resource."
+    ///</remarks>
+    public static SecureHeadersMiddlewareConfiguration UseCrossOriginEmbedderPolicy(
+        this SecureHeadersMiddlewareConfiguration config,
+        CrossOriginEmbedderPolicy.CrossOriginEmbedderOptions value =
+            CrossOriginEmbedderPolicy.CrossOriginEmbedderOptions.RequireCorp)
+    {
+        config.UseCrossOriginEmbedderPolicy = true;
+        config.CrossOriginEmbedderPolicy = new CrossOriginEmbedderPolicy(value);
+        return config;
+    }
 
     /// <summary>
-    /// Used to set a list of URLs that the we want the middleware to NOT operate on
+    /// Used to set a list of URLs that we want the middleware to NOT operate on
     /// </summary>
     /// <param name="config"></param>
     /// <param name="urlsToIgnore">

--- a/src/Extensions/SecureHeadersMiddlewareExtensions.cs
+++ b/src/Extensions/SecureHeadersMiddlewareExtensions.cs
@@ -34,6 +34,7 @@ public static class SecureHeadersMiddlewareExtensions
             .UseXssProtection()
             .UseCrossOriginResourcePolicy()
             .UseCrossOriginOpenerPolicy()
+            .UseCrossOriginEmbedderPolicy()
             .SetUrlsToIgnore(urlIgnoreList)
             .Build();
     }

--- a/src/Guards/BoolValueGuardClausesArgumentException.cs
+++ b/src/Guards/BoolValueGuardClausesArgumentException.cs
@@ -1,0 +1,12 @@
+﻿namespace OwaspHeaders.Core.Guards;
+
+public static class BoolValueGuardClauses
+{
+    public static void MustBeTrue(bool value, string parameterName)
+    {
+        if (!value)
+        {
+            ArgumentExceptionHelper.RaiseNotTrueException(parameterName);
+        }
+    }
+}

--- a/src/Helpers/ArgumentExceptionHelper.cs
+++ b/src/Helpers/ArgumentExceptionHelper.cs
@@ -10,6 +10,14 @@ public static class ArgumentExceptionHelper
         throw new ArgumentException($"No value for {argumentName} was supplied");
     }
 
+    /// <summary>
+    /// Used to raise an <see cref="System.ArgumentException"/> whenever a bool argument should be true, but is not
+    /// </summary>
+    public static void RaiseNotTrueException(string argumentName)
+    {
+        throw new ArgumentException($"Value for {argumentName} must be true");
+    }
+
     public static void RaiseArgumentNullException(string argumentName, string message)
     {
         throw new ArgumentNullException(argumentName, message);

--- a/src/Models/CrossOriginEmbedderPolicy.cs
+++ b/src/Models/CrossOriginEmbedderPolicy.cs
@@ -1,0 +1,73 @@
+﻿namespace OwaspHeaders.Core.Models;
+
+/// <summary>
+/// Cross-Origin-Embedder-Policy
+/// This response header (also named COEP) prevents a document from loading any
+/// cross-origin resources that don’t explicitly grant the document permission
+/// (source Mozilla MDN).
+/// 💡 To fully understand where CORP and COEP work:
+/// - CORP applies on the loaded resource side (resource owner).
+/// - COEP applies on the “loader” of the resource side (consumer of the resource).
+/// MDN Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy
+/// </summary>
+public class CrossOriginEmbedderPolicy : IConfigurationBase
+{
+    /// <summary>
+    /// Cross-Origin-Embedder-Policy
+    /// This response header (also named COEP) prevents a document from loading any
+    /// cross-origin resources that don’t explicitly grant the document permission
+    /// (source Mozilla MDN).
+    /// 💡 To fully understand where CORP and COEP work:
+    /// - CORP applies on the loaded resource side (resource owner).
+    /// - COEP applies on the “loader” of the resource side (consumer of the resource).
+    /// MDN Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy
+    /// </summary>
+    public CrossOriginEmbedderPolicy(CrossOriginEmbedderOptions value =
+        CrossOriginEmbedderOptions.RequireCorp)
+    {
+        OptionValue = value;
+    }
+
+    /// <summary>
+    /// Allows the document to fetch cross-origin resources without giving explicit permission
+    /// through the CORS protocol or the Cross-Origin-Resource-Policy header (it is the default value).
+    /// </summary>
+    public const string UnsafeNoneValue = "unsafe-none";
+
+    /// <summary>
+    /// A document can only load resources from the same origin, or resources explicitly
+    /// marked as loadable from another origin.
+    /// </summary>
+    public const string RequireCorp = "same-require-corp";
+
+    public enum CrossOriginEmbedderOptions
+    {
+        /// <summary>
+        /// <see cref="UnsafeNoneValue"/>
+        /// </summary>
+        UnsafeNone,
+
+        /// <summary>
+        /// <see cref="RequireCorp"/>
+        /// </summary>
+        RequireCorp
+    };
+
+    private CrossOriginEmbedderOptions OptionValue { get; }
+
+    /// <summary>
+    /// Builds the HTTP header value
+    /// </summary>
+    /// <returns>A string representing the HTTP header value</returns>
+    public string BuildHeaderValue()
+    {
+        switch (OptionValue)
+        {
+            case CrossOriginEmbedderOptions.UnsafeNone:
+                return UnsafeNoneValue;
+            case CrossOriginEmbedderOptions.RequireCorp:
+            default:
+                return RequireCorp;
+        }
+    }
+}

--- a/src/Models/SecureHeadersMiddlewareConfiguration.cs
+++ b/src/Models/SecureHeadersMiddlewareConfiguration.cs
@@ -71,6 +71,11 @@ public class SecureHeadersMiddlewareConfiguration
     /// Indicates whether the response should use Cross-Origin-Opener-Policy
     /// </summary>
     public bool UseCrossOriginOpenerPolicy { get; set; }
+    
+    /// <summary>
+    /// Indicates whether the response should use Cross-Origin-Embedder-Policy
+    /// </summary>
+    public bool UseCrossOriginEmbedderPolicy { get; set; }
 
     /// <summary>
     /// The HTTP Strict Transport Security configuration to use
@@ -120,6 +125,8 @@ public class SecureHeadersMiddlewareConfiguration
     public CrossOriginResourcePolicy CrossOriginResourcePolicy { get; set; }
 
     public CrossOriginOpenerPolicy CrossOriginOpenerPolicy { get; set; }
+    
+    public CrossOriginEmbedderPolicy CrossOriginEmbedderPolicy { get; set; }
 
     /// <summary>
     /// A list of URLs that, when requested, should be ignored completely by

--- a/src/Models/SecureHeadersMiddlewareConfiguration.cs
+++ b/src/Models/SecureHeadersMiddlewareConfiguration.cs
@@ -71,7 +71,7 @@ public class SecureHeadersMiddlewareConfiguration
     /// Indicates whether the response should use Cross-Origin-Opener-Policy
     /// </summary>
     public bool UseCrossOriginOpenerPolicy { get; set; }
-    
+
     /// <summary>
     /// Indicates whether the response should use Cross-Origin-Embedder-Policy
     /// </summary>
@@ -125,7 +125,7 @@ public class SecureHeadersMiddlewareConfiguration
     public CrossOriginResourcePolicy CrossOriginResourcePolicy { get; set; }
 
     public CrossOriginOpenerPolicy CrossOriginOpenerPolicy { get; set; }
-    
+
     public CrossOriginEmbedderPolicy CrossOriginEmbedderPolicy { get; set; }
 
     /// <summary>

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>OwaspHeaders.Core</PackageId>
-    <Version>9.7.0</Version>
+    <Version>9.7.1</Version>
     <Authors>Jamie Taylor</Authors>
     <Company>RJJ Software Ltd</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/SecureHeadersMiddleware.cs
+++ b/src/SecureHeadersMiddleware.cs
@@ -131,6 +131,16 @@ public class SecureHeadersMiddleware
             temporaryDictionary.Add(Constants.CrossOriginOpenerPolicyHeaderName,
                 _config.CrossOriginOpenerPolicy.BuildHeaderValue());
         }
+        
+        if (_config.UseCrossOriginEmbedderPolicy)
+        {
+            if (!_config.UseCrossOriginResourcePolicy)
+            {
+                BoolValueGuardClauses.MustBeTrue(_config.UseCrossOriginResourcePolicy, nameof(_config.UseCrossOriginResourcePolicy));
+            }
+            temporaryDictionary.Add(Constants.CrossOriginEmbedderPolicyHeaderName,
+                _config.CrossOriginEmbedderPolicy.BuildHeaderValue());
+        }
 
         return temporaryDictionary.ToFrozenDictionary();
     }

--- a/src/SecureHeadersMiddleware.cs
+++ b/src/SecureHeadersMiddleware.cs
@@ -131,7 +131,7 @@ public class SecureHeadersMiddleware
             temporaryDictionary.Add(Constants.CrossOriginOpenerPolicyHeaderName,
                 _config.CrossOriginOpenerPolicy.BuildHeaderValue());
         }
-        
+
         if (_config.UseCrossOriginEmbedderPolicy)
         {
             if (!_config.UseCrossOriginResourcePolicy)

--- a/tests/OwaspHeaders.Core.Tests/CustomHeaders/CrossOriginOptionsTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/CustomHeaders/CrossOriginOptionsTests.cs
@@ -39,7 +39,7 @@ public class CrossOriginOptionsTests : SecureHeadersTests
         Assert.Equal(CrossOriginOpenerPolicy.SameOriginValue,
             _context.Response.Headers[Constants.CrossOriginOpenerPolicyHeaderName]);
     }
-    
+
     [Fact]
     public async Task When_UseCrossOriginEmbedderPolicyCalled_Header_Is_Present()
     {
@@ -56,16 +56,16 @@ public class CrossOriginOptionsTests : SecureHeadersTests
         // assert
         Assert.True(headerPresentConfig.UseCrossOriginEmbedderPolicy);
         Assert.True(headerPresentConfig.UseCrossOriginResourcePolicy);
-        
+
         Assert.True(_context.Response.Headers.ContainsKey(Constants.CrossOriginResourcePolicyHeaderName));
         Assert.Equal(CrossOriginResourcePolicy.SameOriginValue,
             _context.Response.Headers[Constants.CrossOriginResourcePolicyHeaderName]);
-        
+
         Assert.True(_context.Response.Headers.ContainsKey(Constants.CrossOriginEmbedderPolicyHeaderName));
         Assert.Equal(CrossOriginEmbedderPolicy.RequireCorp,
             _context.Response.Headers[Constants.CrossOriginEmbedderPolicyHeaderName]);
     }
-    
+
     [Fact]
     public async Task When_UseCrossOriginEmbedderPolicyCalled_But_UseCrossOriginResourcePolicy_NotSupplied_Header_Is_Not_Present()
     {
@@ -81,10 +81,10 @@ public class CrossOriginOptionsTests : SecureHeadersTests
         // assert
         Assert.NotNull(exception);
         Assert.IsType<ArgumentException>(exception);
-        
+
         Assert.True(headerPresentConfig.UseCrossOriginEmbedderPolicy);
         Assert.False(headerPresentConfig.UseCrossOriginResourcePolicy);
-        
+
         Assert.False(_context.Response.Headers.ContainsKey(Constants.CrossOriginEmbedderPolicyHeaderName));
     }
 
@@ -119,7 +119,7 @@ public class CrossOriginOptionsTests : SecureHeadersTests
         Assert.False(headerNotPresentConfig.UseCrossOriginOpenerPolicy);
         Assert.False(_context.Response.Headers.ContainsKey(Constants.CrossOriginOpenerPolicyHeaderName));
     }
-    
+
     [Fact]
     public async Task When_UseCrossOriginEmbedderPolicyNotCalled_Header_Not_Present()
     {

--- a/tests/OwaspHeaders.Core.Tests/GuardClauses/HeaderValueGuardClausesStringValues.cs
+++ b/tests/OwaspHeaders.Core.Tests/GuardClauses/HeaderValueGuardClausesStringValues.cs
@@ -7,23 +7,23 @@ public class BoolValueGuardClauses
     {
         // Arrange
         var argName = Guid.NewGuid().ToString();
-        
+
         // Act
         var exception = Record.Exception(() => Guards.BoolValueGuardClauses.MustBeTrue(true, argName));
-        
+
         // Assert
         Assert.Null(exception);
     }
-    
+
     [Fact]
     public void FalseValue_ShouldThrow_ArgumentException()
     {
         // Arrange
         var argName = Guid.NewGuid().ToString();
-        
+
         // Act
         var exception = Record.Exception(() => Guards.BoolValueGuardClauses.MustBeTrue(false, argName));
-        
+
         // Assert
         Assert.NotNull(exception);
         Assert.IsType<ArgumentException>(exception);

--- a/tests/OwaspHeaders.Core.Tests/GuardClauses/HeaderValueGuardClausesStringValues.cs
+++ b/tests/OwaspHeaders.Core.Tests/GuardClauses/HeaderValueGuardClausesStringValues.cs
@@ -1,5 +1,36 @@
 ﻿namespace OwaspHeaders.Core.Tests.GuardClauses;
 
+public class BoolValueGuardClauses
+{
+    [Fact]
+    public void TrueValue_ShouldNotThrow_ArgumentException()
+    {
+        // Arrange
+        var argName = Guid.NewGuid().ToString();
+        
+        // Act
+        var exception = Record.Exception(() => Guards.BoolValueGuardClauses.MustBeTrue(true, argName));
+        
+        // Assert
+        Assert.Null(exception);
+    }
+    
+    [Fact]
+    public void FalseValue_ShouldThrow_ArgumentException()
+    {
+        // Arrange
+        var argName = Guid.NewGuid().ToString();
+        
+        // Act
+        var exception = Record.Exception(() => Guards.BoolValueGuardClauses.MustBeTrue(false, argName));
+        
+        // Assert
+        Assert.NotNull(exception);
+        Assert.IsType<ArgumentException>(exception);
+        Assert.Contains(argName, exception.Message);
+    }
+}
+
 public class HeaderValueGuardClauses
 {
     [Theory]


### PR DESCRIPTION
## Rationale for this PR

This PR adds the following header: Cross-Origin-Opener-Policy. This recommended value header is documented [here](https://owasp.org/www-project-secure-headers/#cross-origin-embedder-policy), and the header itself is documented [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy).

This PR closes #74 

The following is a [minimal code sample](https://gaprogman.github.io/OwaspHeaders.Core/Minimal-Code-Sample/) for the new feature:

```csharp
// in Program.cs
app.UseSecureHeadersMiddleware();
```

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [ :white_check_mark: ] I have added tests to the OwaspHeaders.Core.Tests project
- [ :white_check_mark: ] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [ :white_check_mark: ] I have ensured that the code coverage has not dropped below 65%
- [ :white_check_mark: ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

#### Optional

- [ :white_check_mark: ] I have documented the new feature in the docs directory
- [ :white_check_mark: ] I have provided a code sample, showing how someone could use the new code

### Any Other Information

This section is optional, but it might be useful to list any other information you think is relevant.
