### PR TITLE
Bugfix/coep default header value

### DIFF
--- a/README-NuGet.md
+++ b/README-NuGet.md
@@ -40,7 +40,7 @@ referrer-policy: no-referrer
 cross-origin-resource-policy: same-origin
 cache-control: max-age=0,no-store
 cross-origin-opener-policy: same-origin
-cross-origin-embedder-policy: same-require-corp
+cross-origin-embedder-policy: require-corp
 x-xss-protection: 0
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ referrer-policy: no-referrer
 cross-origin-resource-policy: same-origin
 cache-control: max-age=0,no-store
 cross-origin-opener-policy: same-origin
-cross-origin-embedder-policy: same-require-corp
+cross-origin-embedder-policy: require-corp
 x-xss-protection: 0
 ```
 

--- a/src/Models/CrossOriginEmbedderPolicy.cs
+++ b/src/Models/CrossOriginEmbedderPolicy.cs
@@ -70,4 +70,28 @@ public class CrossOriginEmbedderPolicy : IConfigurationBase
                 return RequireCorp;
         }
     }
+
+    /// <summary>
+    /// Used to calculate whether the current header value is valid
+    /// </summary>
+    /// <param name="useCrossOriginResourcePolicy">
+    /// Whether the CORP header is included in the outer setup
+    /// </param>
+    /// <remarks>
+    /// The value for this header is only invalid if the CORP (Cross-Origin-Resource-Policy) header
+    /// is enabled and the current value for the COEP (Cross-Origin-Embedder-Policy) hedaer is set to
+    /// <see cref="RequireCorp"/>
+    /// </remarks>
+    public bool HeaderValueIsValid(bool useCrossOriginResourcePolicy)
+    {
+        if (OptionValue == CrossOriginEmbedderOptions.RequireCorp)
+        {
+            if (!useCrossOriginResourcePolicy)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/src/Models/CrossOriginEmbedderPolicy.cs
+++ b/src/Models/CrossOriginEmbedderPolicy.cs
@@ -38,7 +38,7 @@ public class CrossOriginEmbedderPolicy : IConfigurationBase
     /// A document can only load resources from the same origin, or resources explicitly
     /// marked as loadable from another origin.
     /// </summary>
-    public const string RequireCorp = "same-require-corp";
+    public const string RequireCorp = "require-corp";
 
     public enum CrossOriginEmbedderOptions
     {

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>OwaspHeaders.Core</PackageId>
-    <Version>9.7.1</Version>
+    <Version>9.7.2</Version>
     <Authors>Jamie Taylor</Authors>
     <Company>RJJ Software Ltd</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/SecureHeadersMiddleware.cs
+++ b/src/SecureHeadersMiddleware.cs
@@ -134,7 +134,7 @@ public class SecureHeadersMiddleware
 
         if (_config.UseCrossOriginEmbedderPolicy)
         {
-            if (!_config.UseCrossOriginResourcePolicy)
+            if (!_config.CrossOriginEmbedderPolicy.HeaderValueIsValid(_config.UseCrossOriginResourcePolicy))
             {
                 BoolValueGuardClauses.MustBeTrue(_config.UseCrossOriginResourcePolicy, nameof(_config.UseCrossOriginResourcePolicy));
             }

--- a/tests/OwaspHeaders.Core.Tests/CustomHeaders/CrossOriginOptionsTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/CustomHeaders/CrossOriginOptionsTests.cs
@@ -144,27 +144,27 @@ public class CrossOriginOptionsTests : SecureHeadersTests
         // Arrange
         var header = new CrossOriginEmbedderPolicy(headerValue);
         const bool useCorp = true;
-        
+
         // Act
         var valid = header.HeaderValueIsValid(useCorp);
 
         // Assert
         Assert.True(valid);
     }
-    
+
     [Fact]
     public void CrossOriginEmbedderPolicy_HeaderValueIsValid_Returns_False_When_HeaderIsInvalid()
     {
         // Arrange
         var header = new CrossOriginEmbedderPolicy(CrossOriginEmbedderPolicy.CrossOriginEmbedderOptions.RequireCorp);
         var useCorp = false;
-        
+
         // Act
         var valid = header.HeaderValueIsValid(useCorp);
 
         // Assert
         Assert.False(valid);
     }
-    
+
 }
 

--- a/tests/OwaspHeaders.Core.Tests/CustomHeaders/CrossOriginOptionsTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/CustomHeaders/CrossOriginOptionsTests.cs
@@ -135,5 +135,36 @@ public class CrossOriginOptionsTests : SecureHeadersTests
         Assert.False(headerNotPresentConfig.UseCrossOriginEmbedderPolicy);
         Assert.False(_context.Response.Headers.ContainsKey(Constants.CrossOriginEmbedderPolicyHeaderName));
     }
+
+    [Theory]
+    [InlineData(CrossOriginEmbedderPolicy.CrossOriginEmbedderOptions.RequireCorp)]
+    [InlineData(CrossOriginEmbedderPolicy.CrossOriginEmbedderOptions.UnsafeNone)]
+    public void CrossOriginEmbedderPolicy_HeaderValueIsValid_Returns_True_When_HeaderIsValid(CrossOriginEmbedderPolicy.CrossOriginEmbedderOptions headerValue)
+    {
+        // Arrange
+        var header = new CrossOriginEmbedderPolicy(headerValue);
+        const bool useCorp = true;
+        
+        // Act
+        var valid = header.HeaderValueIsValid(useCorp);
+
+        // Assert
+        Assert.True(valid);
+    }
+    
+    [Fact]
+    public void CrossOriginEmbedderPolicy_HeaderValueIsValid_Returns_False_When_HeaderIsInvalid()
+    {
+        // Arrange
+        var header = new CrossOriginEmbedderPolicy(CrossOriginEmbedderPolicy.CrossOriginEmbedderOptions.RequireCorp);
+        var useCorp = false;
+        
+        // Act
+        var valid = header.HeaderValueIsValid(useCorp);
+
+        // Assert
+        Assert.False(valid);
+    }
+    
 }
 


### PR DESCRIPTION
## Rationale for this PR

This PR fixes an issue where the default header for COEP (Cross-Origin-Embedder-Policy) was previously reported at `same-require-corp` but should have been `require-corp`.

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [ :white_check_mark: ] I have added tests to the OwaspHeaders.Core.Tests project
- [ :white_check_mark: ] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [ :white_check_mark: ] I have ensured that the code coverage has not dropped below 65%
- [ :white_check_mark: ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)

#### Optional

- [ :negative_squared_cross_mark: ] I have documented the new feature in the docs directory
- [ :negative_squared_cross_mark: ] I have provided a code sample, showing how someone could use the new code

### Any Other Information

This section is optional, but it might be useful to list any other information you think is relevant.
