### PR TITLE
Bugfix/primary constructor editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -98,6 +98,9 @@ csharp_style_deconstructed_variable_declaration = true:suggestion
 csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
+# Primary constructor preferences (disabled due to dotnet-format bug: https://github.com/dotnet/format/issues/2165)
+csharp_style_prefer_primary_constructors = false:silent
+dotnet_diagnostic.IDE0290.severity = none
 ###############################
 # C# Formatting Rules         #
 ###############################

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,7 @@ These items are essential and must be completed for each commit. If they are not
 - [ ] I have ensured that the code coverage has not dropped below 65%
 - [ ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)
 - [ ] I have updated the changelog in the root of the repository
+- [ ] I have avoided using primary constructors in the example project (see README for details)
 
 > [!NOTE]
 > The changelog in the `docs/` directory will be updated automatically when PRs are merged into main.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,43 @@ Please note: this middleware **DOES NOT SUPPORT BLAZOR OR WEBASSEMBLY APPLICATIO
 
 That's it.
 
+## Example Project Coding Guidelines
+
+### Primary Constructors Restriction
+
+**Important**: When contributing to the **example project only** (`OwaspHeaders.Core.Example` directory), please avoid using primary constructors due to a known issue with `dotnet-format` that causes incorrect indentation.
+
+#### ❌ Don't use (in example project):
+
+```csharp
+public class HomeController(ILogger<HomeController> logger) : ControllerBase
+{
+    private readonly ILogger<HomeController> _logger = logger;
+    // dotnet-format will incorrectly indent methods here
+}
+```
+
+#### ✅ Use instead (in example project):
+
+```csharp
+public class HomeController : ControllerBase
+{
+    private readonly ILogger<HomeController> _logger;
+
+    public HomeController(ILogger<HomeController> logger)
+    {
+        _logger = logger;
+    }
+    // dotnet-format handles this correctly
+}
+```
+
+**Why**: This restriction exists because of a bug in `dotnet-format` when processing primary constructors (see [dotnet/format#2165](https://github.com/dotnet/format/issues/2165)). Since this project uses `.editorconfig` and `dotnet-format` for consistent code formatting, primary constructors cause formatting issues that break our CI/CD pipeline.
+
+**Scope**: This restriction applies **only to the example project**. The main OwaspHeaders.Core library does not use primary constructors and is not affected by this issue.
+
+**Future**: This guidance will be removed once the upstream `dotnet-format` bug is resolved.
+
 ## Documentation
 
 The latest documentation for OwaspHeaders.Core can be found at [https://gaprogman.github.io/OwaspHeaders.Core/](https://gaprogman.github.io/OwaspHeaders.Core/).


### PR DESCRIPTION
## Rationale for this PR

This PR closes issue #174 by adding documentation around why we don't want to use primary constructors. Included in this PR is a section in the readme about why we don't want contributors to use them, a checkbox in the PR template, and two lines in the .editorconfig which should stop any IDEs and tooling from suggesting their use.

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [ :question: ] I have added tests to the OwaspHeaders.Core.Tests project
- [ ✅ ] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [ :question: ] I have ensured that the code coverage has not dropped below 65%
- [ :question: ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)
- [ :question: ] I have updated the changelog in the root of the repository

> [!NOTE]
> The changelog in the `docs/` directory will be updated automatically when PRs are merged into main.

#### Optional

- [ ✅ ] I have documented the new feature in the docs directory
- [ :question: ] I have provided a code sample, showing how someone could use the new code

### Any Other Information

This section is optional, but it might be useful to list any other information you think is relevant.
