### PR TITLE
Potential fix for not being able to deploy docs changes

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -65,6 +65,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -15,7 +15,7 @@ jobs:
   sync-changelog:
     runs-on: ubuntu-latest
     name: Sync root changelog to docs changelog
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Rationale for this PR

This PR attempts to fix the broken docs deploy [here](https://github.com/GaProgMan/OwaspHeaders.Core/actions/runs/18161298228) by setting the correct permissions on the pages.yml build pipeline.

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [:question:] I have added tests to the OwaspHeaders.Core.Tests project
- [:question:] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [:question:] I have ensured that the code coverage has not dropped below 65%
- [:question:] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)
- [:question:] I have updated the changelog in the root of the repository
- [:question:] I have avoided using primary constructors in the example project (see README for details)

> [!NOTE]
> The changelog in the `docs/` directory will be updated automatically when PRs are merged into main.

#### Optional

- [:question:] I have documented the new feature in the docs directory
- [:question:] I have provided a code sample, showing how someone could use the new code

### Any Other Information

As this is a workflow specific change, no tests are necessary.

> [!WARNING]
> When merged to main, this PR may attempt to create a new release. Please cancel that build and deploy if it does.