### PR TITLE
Feature/198 mark expect ct obsolete

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -81,17 +81,18 @@ This version corrects an issue where properties in model classes within the `Owa
 
 #### Version 10.3.x
 
-This version marks the `UseExpectCt` builder extension as `[Obsolete]`, addressing issue #198. The Expect-CT header has been deprecated by OWASP (see the [OWASP Secure Headers Project page on Expect-CT](https://owasp.org/www-project-secure-headers/#expect-ct)). It was already absent from `BuildDefaultConfiguration` as of Version 6; the opt-in builder method is retained so existing usages continue to compile, but it is no longer recommended and will be removed in a future major version.
+This version marks the Expect-CT opt-in as `[Obsolete]`, addressing issue #198. The Expect-CT header has been deprecated by OWASP (see the [OWASP Secure Headers Project page on Expect-CT](https://owasp.org/www-project-secure-headers/#expect-ct)). It was already absent from `BuildDefaultConfiguration` as of Version 6; the opt-in surface is retained so existing usages continue to compile, but it is no longer recommended and will be removed in a future major version.
 
 **Changes:**
 
 - Added `[Obsolete]` attribute to `SecureHeadersMiddlewareBuilder.UseExpectCt` with a message pointing callers at the OWASP deprecation notice.
+- Added `[Obsolete]` to the *setters* of `SecureHeadersMiddlewareConfiguration.UseExpectCt` and `SecureHeadersMiddlewareConfiguration.ExpectCt` so that callers who bypass the builder extension and assign these properties directly (for example from `Program.cs`) also see the deprecation warning. The getters remain non-obsolete so that the middleware can read the flag and configuration at request time without producing warnings.
 - Added a test asserting that `BuildDefaultConfiguration()` leaves `UseExpectCt = false` and `ExpectCt = null`, guarding against future regressions that would re-add Expect-CT to the default header chain.
 - Added a reflection-based test asserting that `UseExpectCt` carries the `[Obsolete]` attribute, so the deprecation marker cannot be removed silently.
 
 **Impact:**
 
-- Callers of `UseExpectCt` will see a compiler warning (`CS0618`) prompting them to remove or suppress the opt-in.
+- Callers of `UseExpectCt`, or of `config.UseExpectCt = ...` / `config.ExpectCt = ...`, will see a compiler warning (`CS0618`) prompting them to remove or suppress the opt-in.
 - No runtime behaviour change: Expect-CT remains opt-in and absent from the default header chain.
 
 ### Version 9

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ This changelog represents all the major (i.e. breaking) changes made to the Owas
 
 | Major Version Number | Changes                                                                                                                                                                                                                                                                                                                                                                                                                     |
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 10                    | (as of Nov 12th, 2025) no API changes made yet. Library now supports ASP .NET Core (by updating the TFM to include `net10.0`) <br /> Added support for the EXPERIMENTAL Report-Endpoints header. This is listed nas EXPERIMENTAL (as of January 7th, 2025) on the [relevant MDN docs page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints), it is also not listed as a recommended header. As such, it is not added when the default builder is used <br /> Fixed model properties in OwaspHeaders.Core.Models namespace that were incorrectly set to private - they are now public for serialization and external consumption |
+| 10                    | (as of Nov 12th, 2025) no API changes made yet. Library now supports ASP .NET Core (by updating the TFM to include `net10.0`) <br /> Added support for the EXPERIMENTAL Report-Endpoints header. This is listed nas EXPERIMENTAL (as of January 7th, 2025) on the [relevant MDN docs page](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints), it is also not listed as a recommended header. As such, it is not added when the default builder is used <br /> Fixed model properties in OwaspHeaders.Core.Models namespace that were incorrectly set to private - they are now public for serialization and external consumption <br /> Marked the `UseExpectCt` builder extension as `[Obsolete]` to reflect OWASP's deprecation of the Expect-CT header (issue #198) |
 | 9                    | Removed support for both .NET 6 and .NET 7 as these are no longer supported by Microsoft. It also adds support for .NET 9. <br /> A number of small optimisation have been made to the middleware's `Invoke` method <br /> Added support for both Cross-Origin-Opener-Policy (CORP) and Cross-Origin-Embedder-Policy (COEP) headers <br /> Added support for Clear-Site-Data header with path-specific configuration for logout scenarios <br/> Increased documentation coverage for Content-Security-Policy directive generation |
 | 8                    | Removed support for ASP .NET Core on .NET Framework workflows; example and test projects now have OwaspHeaders.Core prefix, re-architected some of the test classes                                                                                                                                                                                                                                                         |
 | 7                    | Added Cross-Origin-Resource-Policy header to list of defaults; simplified the use of the middleware in Composite Root/Program.cs                                                                                                                                                                                                                                                                                            |
@@ -78,6 +78,21 @@ This version corrects an issue where properties in model classes within the `Owa
 - All affected properties are now properly accessible for serialization scenarios
 - No breaking changes to existing functionality
 - Improved maintainability with centralized ReSharper configuration
+
+#### Version 10.3.x
+
+This version marks the `UseExpectCt` builder extension as `[Obsolete]`, addressing issue #198. The Expect-CT header has been deprecated by OWASP (see the [OWASP Secure Headers Project page on Expect-CT](https://owasp.org/www-project-secure-headers/#expect-ct)). It was already absent from `BuildDefaultConfiguration` as of Version 6; the opt-in builder method is retained so existing usages continue to compile, but it is no longer recommended and will be removed in a future major version.
+
+**Changes:**
+
+- Added `[Obsolete]` attribute to `SecureHeadersMiddlewareBuilder.UseExpectCt` with a message pointing callers at the OWASP deprecation notice.
+- Added a test asserting that `BuildDefaultConfiguration()` leaves `UseExpectCt = false` and `ExpectCt = null`, guarding against future regressions that would re-add Expect-CT to the default header chain.
+- Added a reflection-based test asserting that `UseExpectCt` carries the `[Obsolete]` attribute, so the deprecation marker cannot be removed silently.
+
+**Impact:**
+
+- Callers of `UseExpectCt` will see a compiler warning (`CS0618`) prompting them to remove or suppress the opt-in.
+- No runtime behaviour change: Expect-CT remains opt-in and absent from the default header chain.
 
 ### Version 9
 

--- a/src/Extensions/SecureHeadersMiddlewareBuilder.cs
+++ b/src/Extensions/SecureHeadersMiddlewareBuilder.cs
@@ -315,8 +315,13 @@ public static class SecureHeadersMiddlewareBuilder
     (this SecureHeadersMiddlewareConfiguration config,
         string reportUri, int maxAge = 86400, bool enforce = false)
     {
+        // The UseExpectCt/ExpectCt setters are also marked [Obsolete] to deter
+        // callers from bypassing this (already obsolete) extension. Suppress the
+        // resulting warning here, since this extension is the legitimate writer.
+#pragma warning disable CS0618
         config.UseExpectCt = true;
         config.ExpectCt = new ExpectCt(reportUri, maxAge, enforce);
+#pragma warning restore CS0618
         return config;
     }
 

--- a/src/Extensions/SecureHeadersMiddlewareBuilder.cs
+++ b/src/Extensions/SecureHeadersMiddlewareBuilder.cs
@@ -302,8 +302,15 @@ public static class SecureHeadersMiddlewareBuilder
     /// Transparency policy.
     /// </param>
     /// <exception cref="ArgumentException">
-    /// An ArgumentException is thrown when no Report URI is supplied 
+    /// An ArgumentException is thrown when no Report URI is supplied
     /// </exception>
+    /// <remarks>
+    /// The Expect-CT header has been deprecated by OWASP. See
+    /// https://owasp.org/www-project-secure-headers/#expect-ct for details. This method
+    /// is retained so that existing opt-in usages continue to compile, but it is no
+    /// longer recommended and will be removed in a future major version.
+    /// </remarks>
+    [Obsolete("The Expect-CT header has been deprecated by OWASP and will be removed in a future major version. See https://owasp.org/www-project-secure-headers/#expect-ct for details.", false)]
     public static SecureHeadersMiddlewareConfiguration UseExpectCt
     (this SecureHeadersMiddlewareConfiguration config,
         string reportUri, int maxAge = 86400, bool enforce = false)

--- a/src/Models/SecureHeadersMiddlewareConfiguration.cs
+++ b/src/Models/SecureHeadersMiddlewareConfiguration.cs
@@ -55,7 +55,18 @@ public class SecureHeadersMiddlewareConfiguration
     /// <summary>
     /// Indicates whether the response should use Expect-CT
     /// </summary>
-    public bool UseExpectCt { get; set; }
+    /// <remarks>
+    /// The Expect-CT header has been deprecated by OWASP. The setter is marked
+    /// <see cref="ObsoleteAttribute"/> so that callers who bypass the (also obsolete)
+    /// <c>UseExpectCt</c> builder extension still see a deprecation warning. The getter
+    /// remains non-obsolete so the middleware can read the flag without warnings.
+    /// </remarks>
+    public bool UseExpectCt
+    {
+        get;
+        [Obsolete("Expect-CT has been deprecated by OWASP and will be removed in a future major version. See https://owasp.org/www-project-secure-headers/#expect-ct for details.", false)]
+        set;
+    }
 
     /// <summary>
     /// Indicates whether the response should use Cache-Control
@@ -130,7 +141,18 @@ public class SecureHeadersMiddlewareConfiguration
     /// <summary>
     /// The Expect-CT configuration to use
     /// </summary>
-    public ExpectCt ExpectCt { get; set; }
+    /// <remarks>
+    /// The Expect-CT header has been deprecated by OWASP. The setter is marked
+    /// <see cref="ObsoleteAttribute"/> so that callers who assign this directly still see
+    /// a deprecation warning. The getter remains non-obsolete so the middleware can read
+    /// the value without warnings.
+    /// </remarks>
+    public ExpectCt ExpectCt
+    {
+        get;
+        [Obsolete("Expect-CT has been deprecated by OWASP and will be removed in a future major version. See https://owasp.org/www-project-secure-headers/#expect-ct for details.", false)]
+        set;
+    }
 
     public CrossOriginResourcePolicy CrossOriginResourcePolicy { get; set; }
 

--- a/src/OwaspHeaders.Core.csproj
+++ b/src/OwaspHeaders.Core.csproj
@@ -8,7 +8,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>OwaspHeaders.Core</PackageId>
-    <Version>10.2.0</Version>
+    <Version>10.3.0</Version>
     <Authors>Jamie Taylor</Authors>
     <Company>RJJ Software Ltd</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/OwaspHeaders.Core.Tests/CustomHeaders/ExpectCtOptionsTests.cs
+++ b/tests/OwaspHeaders.Core.Tests/CustomHeaders/ExpectCtOptionsTests.cs
@@ -1,5 +1,8 @@
 ﻿namespace OwaspHeaders.Core.Tests.CustomHeaders;
 
+// Expect-CT has been deprecated by OWASP and UseExpectCt is marked [Obsolete].
+// These tests still exercise the opt-in code path while it exists in the codebase.
+#pragma warning disable CS0618
 public class ExpectCtOptionsTests : SecureHeadersTests
 {
     [Fact]
@@ -37,6 +40,32 @@ public class ExpectCtOptionsTests : SecureHeadersTests
     }
 
     [Fact]
+    public void Default_Configuration_Does_Not_Include_ExpectCt()
+    {
+        // arrange / act
+        var defaultConfig = SecureHeadersMiddlewareExtensions.BuildDefaultConfiguration();
+
+        // assert
+        Assert.False(defaultConfig.UseExpectCt,
+            "Expect-CT has been deprecated by OWASP and must not be enabled by BuildDefaultConfiguration.");
+        Assert.Null(defaultConfig.ExpectCt);
+    }
+
+    [Fact]
+    public void UseExpectCt_Is_Marked_Obsolete()
+    {
+        // arrange
+        var method = typeof(SecureHeadersMiddlewareBuilder)
+            .GetMethod(nameof(SecureHeadersMiddlewareBuilder.UseExpectCt));
+
+        // act
+        var obsolete = method?.GetCustomAttribute<ObsoleteAttribute>();
+
+        // assert
+        Assert.NotNull(obsolete);
+    }
+
+    [Fact]
     public async Task When_UseExpectCtCalled_HeaderIsPresent_ReportUri_Optional()
     {
         // arrange
@@ -54,3 +83,4 @@ public class ExpectCtOptionsTests : SecureHeadersTests
             _context.Response.Headers[Constants.ExpectCtHeaderName]);
     }
 }
+#pragma warning restore CS0618

--- a/tests/OwaspHeaders.Core.Tests/CustomHeaders/GlobalUsings.cs
+++ b/tests/OwaspHeaders.Core.Tests/CustomHeaders/GlobalUsings.cs
@@ -1,6 +1,7 @@
 ﻿global using System;
 global using System.Collections.Generic;
 global using System.Linq;
+global using System.Reflection;
 global using System.Threading;
 global using System.Threading.Tasks;
 global using Microsoft.AspNetCore.Builder;


### PR DESCRIPTION
## Rationale for this PR

This PR marks the `UseExpectCt` method as obsolete, adds a unit test to ensure that we're not adding it in the default middleware config builder, and adds a test to ensure that the `UseExpectCt` method has the Obsolete attribute attached.

Also included is an update to the root-level changelog (which should propagate to the docs-level changelog automatically) and a minor version bump.

This PR addresses some of (but does not close) #198. There will be further work required to remove this header completely in the next major version.

### PR Checklist

Feel free to either check the following items (by place an `x` inside of the square brackets) or by replacing the square brackets with a relevant emoji from the following list:

- :white_check_mark: to indicate that you have checked something off
- :negative_squared_cross_mark: to indicate that you haven't checked something off
- :question: to indicate that something might not be relevant (writing tests for documentation changes, for instance)

#### Essential

These items are essential and must be completed for each commit. If they are not completed, the PR may not be accepted.

- [ :white_check_mark: ] I have added tests to the OwaspHeaders.Core.Tests project
- [ :white_check_mark: ] I have run the `dotnet-format` command and fixed any .editorconfig issues
- [ :white_check_mark: ] I have ensured that the code coverage has not dropped below 65%
- [ :white_check_mark: ] I have increased the version number in OwaspHeaders.Core.csproj (only relevant for code changes)
- [ :white_check_mark: ] I have updated the changelog in the root of the repository
- [ :white_check_mark: ] I have avoided using primary constructors in the example project (see README for details)

> [!NOTE]
> The changelog in the `docs/` directory will be updated automatically when PRs are merged into main.

#### Optional

- [ :question: ] I have documented the new feature in the docs directory
- [ :question: ] I have provided a code sample, showing how someone could use the new code
