### PR TITLE
[Jun 8, 2026] zizmor fixes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,6 +69,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 1
+        persist-credentials: false
 
     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
@@ -51,6 +52,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
@@ -80,6 +82,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
+        persist-credentials: false
       
     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
@@ -124,6 +127,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
+        persist-credentials: false
       
     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -12,8 +12,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  attestations: write
 
 jobs:
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,6 +31,11 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    # actions/configure-pages reads the existing Pages config via the REST API
+    # (GET /repos/{owner}/{repo}/pages) to derive base_path, which needs Pages read.
+    permissions:
+      contents: read
+      pages: read
     defaults:
       run:
         working-directory: docs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,11 +16,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Sets the default permissions of the GITHUB_TOKEN to read-only.
+# The `deploy` job grants itself the elevated `pages: write` and
+# `id-token: write` permissions it needs for deployment.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow one concurrent deployment
 concurrency:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Ruby
         uses: ruby/setup-ruby@c515ec17f69368147deb311832da000dd229d338 # v1.297.0
         with:
@@ -49,9 +51,10 @@ jobs:
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build --baseurl "${STEPS_PAGES_OUTPUTS_BASE_PATH}"
         env:
           JEKYLL_ENV: production
+          STEPS_PAGES_OUTPUTS_BASE_PATH: ${{ steps.pages.outputs.base_path }}
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  attestations: write
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
@@ -52,6 +53,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
+        persist-credentials: false
       
     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
@@ -78,6 +80,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
+        persist-credentials: false
       
     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
@@ -95,7 +98,7 @@ jobs:
         subject-path: ${{ github.workspace }}/**/*.nupkg
 
     - name: NuGet login (OIDC → temp API key)
-      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
       id: nuget-login
       with:
         user: ${{ secrets.NUGET_USER }}
@@ -104,4 +107,6 @@ jobs:
       # use of --skip-duplicate here will stop NuGet from complaining
       # if we try to publish the same version multiple times by making
       # publish actions idempotent.
-      run: dotnet nuget push **/*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
+      run: dotnet nuget push **/*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${STEPS_NUGET_LOGIN_OUTPUTS_NUGET_API_KEY} --skip-duplicate
+      env:
+        STEPS_NUGET_LOGIN_OUTPUTS_NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,6 @@ jobs:
       # use of --skip-duplicate here will stop NuGet from complaining
       # if we try to publish the same version multiple times by making
       # publish actions idempotent.
-      run: dotnet nuget push **/*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${STEPS_NUGET_LOGIN_OUTPUTS_NUGET_API_KEY} --skip-duplicate
+      run: dotnet nuget push **/*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key "${STEPS_NUGET_LOGIN_OUTPUTS_NUGET_API_KEY}" --skip-duplicate
       env:
         STEPS_NUGET_LOGIN_OUTPUTS_NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}

--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Sync changelog files
         run: |


### PR DESCRIPTION
## Rationale for this PR

This PR provides the output of running [zizmor](https://github.com/zizmorcore/zizmor) on the repo locally. The commands ran on the codebase were:

```bash
# check for issues
zizmor .github/workflows
```

Which gave the following output:

```bash
INFO zizmor: 🌈 zizmor v1.25.2
 INFO audit: zizmor: 🌈 completed .github/workflows/codeql.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/coverage-comment.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/dotnet.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/pages.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/release.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/scorecard.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/sync-changelog.yml
help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/codeql.yml:70:7
   |
70 |       - name: Checkout repository
   |  _______^
71 | |       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
72 | |
73 | |     # Initializes the CodeQL tools for scanning.
   | |________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> .github/workflows/coverage-comment.yml:3:1
  |
3 | / on:
4 | |   workflow_run:
5 | |     workflows: ["Build repo"]
6 | |     types:
7 | |       - completed
  | |_________________^ workflow_run is almost always used insecurely
  |
  = note: audit confidence → Medium

error[template-injection]: code injection via template expansion
  --> .github/workflows/coverage-comment.yml:67:32
   |
60 |         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
   |         -------------------------------------------------------------------- action accepts arbitrary code
...
63 |           script: |
   |           ------ via this input
...
67 |               commit_sha: '${{ github.event.workflow_run.head_sha }}',
   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → High

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/dotnet.yml:25:7
   |
25 |       - name: Checkout code
   |  _______^
26 | |       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
27 | |       with:
28 | |         fetch-depth: 1
29 | |
30 | |     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
31 | |     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
   | |__________________________________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/dotnet.yml:50:7
   |
50 |       - name: Checkout code
   |  _______^
51 | |       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
52 | |       with:
53 | |         fetch-depth: 0
54 | |
55 | |     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
56 | |     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
   | |__________________________________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/dotnet.yml:79:7
   |
79 |       - name: Checkout code
   |  _______^
80 | |       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
81 | |       with:
82 | |         fetch-depth: 0
83 | |
84 | |     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
85 | |     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
   | |__________________________________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
   --> .github/workflows/dotnet.yml:123:7
    |
123 |       - name: Checkout code
    |  _______^
124 | |       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
125 | |       with:
126 | |         fetch-depth: 0
127 | |
128 | |     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
129 | |     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
    | |__________________________________________________________________________________________^ does not set persist-credentials: false
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

error[excessive-permissions]: overly broad permissions
  --> .github/workflows/dotnet.yml:15:3
   |
15 |   id-token: write
   |   ^^^^^^^^^^^^^^^ id-token: write is overly broad at the workflow level
   |
   = note: audit confidence → High

error[excessive-permissions]: overly broad permissions
  --> .github/workflows/dotnet.yml:16:3
   |
16 |   attestations: write
   |   ^^^^^^^^^^^^^^^^^^^ attestations: write is overly broad at the workflow level
   |
   = note: audit confidence → High

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/pages.yml:38:9
   |
38 |         - name: Checkout
   |  _________^
39 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
   | |________________________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

error[excessive-permissions]: overly broad permissions
  --> .github/workflows/pages.yml:22:3
   |
22 |   pages: write
   |   ^^^^^^^^^^^^ pages: write is overly broad at the workflow level
   |
   = note: audit confidence → High

error[excessive-permissions]: overly broad permissions
  --> .github/workflows/pages.yml:23:3
   |
23 |   id-token: write
   |   ^^^^^^^^^^^^^^^ id-token: write is overly broad at the workflow level
   |
   = note: audit confidence → High

info[template-injection]: code injection via template expansion
  --> .github/workflows/pages.yml:52:54
   |
52 |         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
   |         --- this run block                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/release.yml:27:7
   |
27 |       - name: Checkout code
   |  _______^
28 | |       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
29 | |       with:
30 | |         fetch-depth: 0
31 | |
32 | |     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
33 | |     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
   | |__________________________________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/release.yml:51:7
   |
51 |       - name: Checkout code
   |  _______^
52 | |       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
53 | |       with:
54 | |         fetch-depth: 0
55 | |
56 | |     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
57 | |     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
   | |__________________________________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/release.yml:77:7
   |
77 |       - name: Checkout code
   |  _______^
78 | |       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
79 | |       with:
80 | |         fetch-depth: 0
81 | |
82 | |     # The NuGet package we're building supports .NET 8, .NET 9, and .NET 10.
83 | |     # .NET 8 and 9 are pre-installed on ubuntu-latest, so we only need to install .NET 10.
   | |__________________________________________________________________________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

error[excessive-permissions]: overly broad permissions
  --> .github/workflows/release.yml:17:3
   |
17 |   id-token: write
   |   ^^^^^^^^^^^^^^^ id-token: write is overly broad at the workflow level
   |
   = note: audit confidence → High

error[excessive-permissions]: overly broad permissions
  --> .github/workflows/release.yml:18:3
   |
18 |   attestations: write
   |   ^^^^^^^^^^^^^^^^^^^ attestations: write is overly broad at the workflow level
   |
   = note: audit confidence → High

info[template-injection]: code injection via template expansion
   --> .github/workflows/release.yml:107:102
    |
107 |       run: dotnet nuget push **/*.nupkg --source 'https://api.nuget.org/v3/index.json' --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}...
    |       --- this run block                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
  --> .github/workflows/release.yml:98:68
   |
98 |       uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1
   |       ----------------------------------------------------------   ^^ points to commit 8d196754b403
   |       |
   |       is pointed to by tag v1.1.0
   |
   = note: audit confidence → High
   = note: this finding has an auto-fix

help[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/sync-changelog.yml:20:9
   |
20 |         - name: Checkout code
   |  _________^
21 | |         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
22 | |         with:
23 | |           fetch-depth: 0
   | |________________________^ does not set persist-credentials: false
   |
   = note: audit confidence → Low
   = note: this finding has an auto-fix

46 findings (25 suppressed, 13 unsafe fixes): 2 informational, 10 low, 1 medium, 8 high

Fix Summary
Successfully applied fixes to 5 files:
  .github/workflows/pages.yml: 2 fixes
  .github/workflows/codeql.yml: 1 fixes
  .github/workflows/dotnet.yml: 4 fixes
  .github/workflows/sync-changelog.yml: 1 fixes
  .github/workflows/release.yml: 5 fixes
```

In order to fix these issues, the following command was run:

```bash
# run all automatable fixes
zizmor .github/workflows --fix=all
```

### PR Checklist

Not going to include the PR checklist as this is purely an Actions-based PR (i.e. not a code change).

### Any Other Information